### PR TITLE
extend configurable values for resources, annotations and mounts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,19 @@
  name: Release Charts
+ 
  on:
    push:
      branches:
        - main
+ 
  jobs:
    release:
      runs-on: ubuntu-latest
      steps:
        - name: Checkout
-         uses: actions/checkout@v1
+         uses: actions/checkout@v2
+
+       - name: Fetch history
+         run: git fetch --prune --unshallow
 
        - name: Configure Git
          run: |
@@ -16,6 +21,6 @@
            git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
        - name: Run chart-releaser
-         uses: helm/chart-releaser-action@v1.0.0
+         uses: helm/chart-releaser-action@v1.2.1
          env:
            CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -3,6 +3,6 @@ name: flux2
 description: A Helm chart for flux2
 
 type: application
-version: 0.0.1
+version: 0.1.0
 
 appVersion: "0.20.1"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.1](https://img.shields.io/badge/AppVersion-0.20.1-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.1](https://img.shields.io/badge/AppVersion-0.20.1-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -8,25 +8,74 @@ A Helm chart for flux2
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| helmcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
+| helmcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | helmcontroller.create | bool | `true` |  |
 | helmcontroller.image | string | `"fluxcd/helm-controller"` |  |
+| helmcontroller.labels | object | `{}` |  |
+| helmcontroller.resources.limits.cpu | string | `"1000m"` |  |
+| helmcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| helmcontroller.resources.requests.cpu | string | `"100m"` |  |
+| helmcontroller.resources.requests.memory | string | `"64Mi"` |  |
+| helmcontroller.serviceaccount.annotations | object | `{}` |  |
 | helmcontroller.tag | string | `"v0.12.1"` |  |
+| imageautomationcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
+| imageautomationcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | imageautomationcontroller.create | bool | `true` |  |
 | imageautomationcontroller.image | string | `"fluxcd/image-automation-controller"` |  |
+| imageautomationcontroller.labels | object | `{}` |  |
+| imageautomationcontroller.resources.limits.cpu | string | `"1000m"` |  |
+| imageautomationcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| imageautomationcontroller.resources.requests.cpu | string | `"100m"` |  |
+| imageautomationcontroller.resources.requests.memory | string | `"64Mi"` |  |
+| imageautomationcontroller.serviceaccount.annotations | object | `{}` |  |
 | imageautomationcontroller.tag | string | `"v0.16.0"` |  |
+| imagereflectorcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
+| imagereflectorcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | imagereflectorcontroller.create | bool | `true` |  |
 | imagereflectorcontroller.image | string | `"fluxcd/image-reflector-controller"` |  |
+| imagereflectorcontroller.labels | object | `{}` |  |
+| imagereflectorcontroller.resources.limits.cpu | string | `"1000m"` |  |
+| imagereflectorcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| imagereflectorcontroller.resources.requests.cpu | string | `"100m"` |  |
+| imagereflectorcontroller.resources.requests.memory | string | `"64Mi"` |  |
+| imagereflectorcontroller.serviceaccount.annotations | object | `{}` |  |
 | imagereflectorcontroller.tag | string | `"v0.13.0"` |  |
+| kustomizecontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
+| kustomizecontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | kustomizecontroller.create | bool | `true` |  |
+| kustomizecontroller.extraSecretMounts | list | `[]` |  |
 | kustomizecontroller.image | string | `"fluxcd/kustomize-controller"` |  |
+| kustomizecontroller.labels | object | `{}` |  |
+| kustomizecontroller.resources.limits.cpu | string | `"1000m"` |  |
+| kustomizecontroller.resources.limits.memory | string | `"1Gi"` |  |
+| kustomizecontroller.resources.requests.cpu | string | `"100m"` |  |
+| kustomizecontroller.resources.requests.memory | string | `"64Mi"` |  |
+| kustomizecontroller.serviceaccount.annotations | object | `{}` |  |
 | kustomizecontroller.tag | string | `"v0.16.0"` |  |
+| notificationcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
+| notificationcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | notificationcontroller.create | bool | `true` |  |
 | notificationcontroller.image | string | `"fluxcd/notification-controller"` |  |
+| notificationcontroller.labels | object | `{}` |  |
+| notificationcontroller.resources.limits.cpu | string | `"1000m"` |  |
+| notificationcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| notificationcontroller.resources.requests.cpu | string | `"100m"` |  |
+| notificationcontroller.resources.requests.memory | string | `"64Mi"` |  |
+| notificationcontroller.serviceaccount.annotations | object | `{}` |  |
 | notificationcontroller.tag | string | `"v0.18.1"` |  |
 | policies.create | bool | `true` |  |
 | rbac.create | bool | `true` |  |
+| sourcecontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
+| sourcecontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | sourcecontroller.create | bool | `true` |  |
 | sourcecontroller.image | string | `"fluxcd/source-controller"` |  |
+| sourcecontroller.labels | object | `{}` |  |
+| sourcecontroller.resources.limits.cpu | string | `"1000m"` |  |
+| sourcecontroller.resources.limits.memory | string | `"1Gi"` |  |
+| sourcecontroller.resources.requests.cpu | string | `"100m"` |  |
+| sourcecontroller.resources.requests.memory | string | `"64Mi"` |  |
+| sourcecontroller.serviceaccount.annotations | object | `{}` |  |
 | sourcecontroller.tag | string | `"v0.17.1"` |  |
 
 ----------------------------------------------

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: helm-controller
+  {{- with .Values.helmcontroller.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -17,11 +20,12 @@ spec:
       app: helm-controller
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "8080"
-        prometheus.io/scrape: "true"
+      {{- with .Values.helmcontroller.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: helm-controller
+{{ with .Values.helmcontroller.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       containers:
       - args:
@@ -52,13 +56,9 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
+        {{- with .Values.helmcontroller.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: image-automation-controller
+  {{- with .Values.imageautomationcontroller.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -17,11 +20,12 @@ spec:
       app: image-automation-controller
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "8080"
-        prometheus.io/scrape: "true"
+      {{- with .Values.imageautomationcontroller.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: image-automation-controller
+{{- with .Values.imageautomationcontroller.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       containers:
       - args:
@@ -52,13 +56,9 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
+        {{- with .Values.imageautomationcontroller.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: image-reflector-controller
+  {{- with .Values.imagereflectorcontroller.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -17,11 +20,12 @@ spec:
       app: image-reflector-controller
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "8080"
-        prometheus.io/scrape: "true"
+      {{- with .Values.imagereflectorcontroller.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: image-reflector-controller
+{{- with .Values.imagereflectorcontroller.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       containers:
       - args:
@@ -52,13 +56,9 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
+        {{- with .Values.imagereflectorcontroller.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kustomize-controller
+  {{- with .Values.kustomizecontroller.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -17,11 +20,12 @@ spec:
       app: kustomize-controller
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "8080"
-        prometheus.io/scrape: "true"
+      {{- with .Values.kustomizecontroller.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: kustomize-controller
+{{- with .Values.kustomizecontroller.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       containers:
       - args:
@@ -52,19 +56,21 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
+        {{- with .Values.kustomizecontroller.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
           name: temp
+      {{- range .Values.kustomizecontroller.extraSecretMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          subPath: {{ .subPath }}
+          readOnly: {{ .readOnly }}
+      {{- end }}
       securityContext:
         fsGroup: 1337
       serviceAccountName: kustomize-controller
@@ -72,4 +78,9 @@ spec:
       volumes:
       - emptyDir: {}
         name: temp
+    {{- range .Values.kustomizecontroller.extraSecretMounts }}
+      - name: {{ .name }}
+        secret:
+          secretName: {{ .secretName }}
+    {{- end }}
 {{- end }}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: notification-controller
+  {{- with .Values.notificationcontroller.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -49,11 +52,13 @@ spec:
       app: notification-controller
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "8080"
-        prometheus.io/scrape: "true"
+    metadata:
+      {{- with .Values.notificationcontroller.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: notification-controller
+{{- with .Values.notificationcontroller.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       containers:
       - args:
@@ -87,13 +92,9 @@ spec:
           httpGet:
             path: /readyz
             port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
+        {{- with .Values.notificationcontroller.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: source-controller
+  {{- with .Values.sourcecontroller.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -35,11 +38,12 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "8080"
-        prometheus.io/scrape: "true"
+      {{- with .Values.sourcecontroller.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: source-controller
+{{- with .Values.sourcecontroller.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
       containers:
       - args:
@@ -73,13 +77,9 @@ spec:
           httpGet:
             path: /
             port: http
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 50m
-            memory: 64Mi
+        {{- with .Values.sourcecontroller.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -2,31 +2,116 @@ helmcontroller:
   create: true
   image: fluxcd/helm-controller
   tag: v0.12.1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+  labels: {}
+  serviceaccount:
+    annotations: {}
 
 imageautomationcontroller:
   create: true
   image: fluxcd/image-automation-controller
   tag: v0.16.0
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+  labels: {}
+  serviceaccount:
+    annotations: {}
 
 imagereflectorcontroller:
   create: true
   image: fluxcd/image-reflector-controller
   tag: v0.13.0
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+  labels: {}
+  serviceaccount:
+    annotations: {}
 
 kustomizecontroller:
   create: true
   image: fluxcd/kustomize-controller
   tag: v0.16.0
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+  labels: {}
+  serviceaccount:
+    annotations: {}
+  # Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+  extraSecretMounts: []
+    # - name: secret-files
+    #   mountPath: /etc/secrets
+    #   subPath: ""
+    #   secretName: secret-files
+    #   readOnly: true
 
 notificationcontroller:
   create: true
   image: fluxcd/notification-controller
   tag: v0.18.1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+  labels: {}
+  serviceaccount:
+    annotations: {}
 
 sourcecontroller:
   create: true
   image: fluxcd/source-controller
   tag: v0.17.1
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scrape: "true"
+  labels: {}
+  serviceaccount:
+    annotations: {}
 
 policies:
   create: true


### PR DESCRIPTION
You are able to add custom annotation, labes and resources limits for cpu and memory,
Furthermore there is an addition to mount secrets in kustomize-controller so it can access private repos with creds when its used without source-controller.