### PR TITLE
update to 0.21.1 and add unittests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Create a report to help us improve
+title: "Issue Title"
+labels: [bug]
+assignees:
+  - 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please be cautious with the sensitive information/logs while filing the issue.
+  - type: textarea
+    id: desc
+    attributes:
+      label: Describe the bug a clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: input
+    id: helm-version
+    attributes:
+      label: What's your helm version?
+      description: Enter the output of `$ helm version`
+      placeholder: Copy paste the entire output of the above 
+    validations:
+      required: true
+  - type: input
+    id: kubectl-version
+    attributes:
+      label: What's your kubectl version?
+      description: Enter the output of `$ kubectl version`
+    validations:
+      required: true
+
+  - type: input
+    id: chart-version
+    attributes:
+      label: What's the chart version?
+      description: Enter the version of the chart that you encountered this bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Enter exactly what happened.
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What you expected to happen?
+      description: Enter what you expected to happen.
+    validations:
+      required: false
+
+  - type: textarea
+    id: how-to-reproduce
+    attributes:
+      label: How to reproduce it?
+      description: As minimally and precisely as possible.
+    validations:
+      required: false
+
+  - type: textarea
+    id: changed-values
+    attributes:
+      label: Enter the changed values of values.yaml?
+      description: Please enter only values which differ from the defaults. Enter `NONE` if nothing's changed.
+      placeholder: 'key: value'
+    validations:
+      required: false
+
+  - type: textarea
+    id: helm-command
+    attributes:
+      label: Enter the command that you execute and failing/misfunctioning.
+      description: Enter the command as-is as how you executed.
+      placeholder: helm install my-release flux-community/flux2 --version version --values values.yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else we need to know?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest an idea for this project
+title: "Issue Title"
+labels: [enhancement]
+assignees:
+  - 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+
+  - type: textarea
+    id: desc
+    attributes:
+      label: Is your feature request related to a problem ?
+      description: Give a clear and concise description of what the problem is.
+      placeholder:  ex. I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: prop-solution
+    attributes:
+      label: Describe the solution you'd like.
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+      
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered.
+      description: A clear and concise description of any alternative solutions or features you've considered. If nothing, please enter `NONE`
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-ctxt
+    attributes:
+      label: Additional context.
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,7 +26,7 @@ body:
       description: A clear and concise description of what you want to happen.
     validations:
       required: true
-      
+
   - type: textarea
     id: alternatives
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,7 @@ description: Suggest an idea for this project
 title: "Issue Title"
 labels: [enhancement]
 assignees:
-  - 
+  -
 body:
   - type: markdown
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@ Thank you for contributing to fluxcd-community/helm-charts.
 Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:
 
 * https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
+* https://helm.sh/docs/chart_best_practices/
 
 Please make sure you test your changes before you push them.
 Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -31,6 +31,12 @@ jobs:
             echo "::set-output name=changed::true"
           fi
 
+      - name: install helm unittest plugin
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm env
+          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.8
+
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ FLUX2_VERSION ?= v0.20.1
 
 all: fetch generate helm-docs
 
-fetch: 
+fetch:
 	@if [ ! -d ".work/flux2" ]; then \
 		cd .work && git clone "https://github.com/fluxcd/flux2.git"; \
 	fi
@@ -19,7 +19,7 @@ helm-docs:
 	helm-docs
 
 # manipulate:
-# ToDo: 
+# ToDo:
 # 	- split files in crds & deployments
 # 	- insert if/end to
 

--- a/charts/flux2/.helmignore
+++ b/charts/flux2/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+
+tests/

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -3,6 +3,6 @@ name: flux2
 description: A Helm chart for flux2
 
 type: application
-version: 0.2.2
+version: 0.3.0
 
-appVersion: "0.20.1"
+appVersion: "0.21.1"

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -3,6 +3,6 @@ name: flux2
 description: A Helm chart for flux2
 
 type: application
-version: 0.3.0
+version: "0.3.0"
 
 appVersion: "0.21.1"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -8,7 +8,7 @@ A Helm chart for flux2
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy.  In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicity in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
+| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy.  In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
 | helmcontroller.affinity | object | `{}` |  |
 | helmcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | helmcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.20.1](https://img.shields.io/badge/AppVersion-0.20.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.21.1](https://img.shields.io/badge/AppVersion-0.21.1-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -8,6 +8,7 @@ A Helm chart for flux2
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy.  In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicity in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
 | helmcontroller.affinity | object | `{}` |  |
 | helmcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | helmcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
@@ -36,7 +37,7 @@ A Helm chart for flux2
 | imageautomationcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | imageautomationcontroller.serviceaccount.annotations | object | `{}` |  |
 | imageautomationcontroller.serviceaccount.create | bool | `true` |  |
-| imageautomationcontroller.tag | string | `"v0.16.0"` |  |
+| imageautomationcontroller.tag | string | `"v0.16.1"` |  |
 | imageautomationcontroller.tolerations | list | `[]` |  |
 | imagereflectorcontroller.affinity | object | `{}` |  |
 | imagereflectorcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -100,7 +101,7 @@ A Helm chart for flux2
 | sourcecontroller.resources.requests.memory | string | `"64Mi"` |  |
 | sourcecontroller.serviceaccount.annotations | object | `{}` |  |
 | sourcecontroller.serviceaccount.create | bool | `true` |  |
-| sourcecontroller.tag | string | `"v0.17.1"` |  |
+| sourcecontroller.tag | string | `"v0.17.2"` |  |
 | sourcecontroller.tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/flux2/templates/cluster-reconciler-clusterrolebinding.yaml
+++ b/charts/flux2/templates/cluster-reconciler-clusterrolebinding.yaml
@@ -2,6 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: cluster-reconciler
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/flux2/templates/crd-controller-clusterrole.yaml
+++ b/charts/flux2/templates/crd-controller-clusterrole.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: crd-controller
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
 rules:
 - apiGroups:
   - source.toolkit.fluxcd.io

--- a/charts/flux2/templates/crd-controller-clusterrolebinding.yaml
+++ b/charts/flux2/templates/crd-controller-clusterrolebinding.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: crd-controller
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/flux2/templates/helm-controller-crds.yaml
+++ b/charts/flux2/templates/helm-controller-crds.yaml
@@ -6,6 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: helmreleases.helm.toolkit.fluxcd.io
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
 spec:
   group: helm.toolkit.fluxcd.io
   names:

--- a/charts/flux2/templates/helm-controller-sa.yaml
+++ b/charts/flux2/templates/helm-controller-sa.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: helm-controller
   {{- with .Values.helmcontroller.serviceaccount.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: helm-controller
 spec:
@@ -21,7 +23,7 @@ spec:
     spec:
       containers:
       - args:
-        - --events-addr=http://notification-controller/
+        - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json

--- a/charts/flux2/templates/image-automation-controller-crds.yaml
+++ b/charts/flux2/templates/image-automation-controller-crds.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: imageupdateautomations.image.toolkit.fluxcd.io
 spec:
   group: image.toolkit.fluxcd.io

--- a/charts/flux2/templates/image-automation-controller-sa.yaml
+++ b/charts/flux2/templates/image-automation-controller-sa.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: image-automation-controller
   {{- with .Values.imageautomationcontroller.serviceaccount.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: image-automation-controller
 spec:
@@ -21,7 +23,7 @@ spec:
     spec:
       containers:
       - args:
-        - --events-addr=http://notification-controller/
+        - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json

--- a/charts/flux2/templates/image-reflector-controller-crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller-crds.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: imagepolicies.image.toolkit.fluxcd.io
 spec:
   group: image.toolkit.fluxcd.io

--- a/charts/flux2/templates/image-reflector-controller-sa.yaml
+++ b/charts/flux2/templates/image-reflector-controller-sa.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: image-reflector-controller
   {{- with .Values.imagereflectorcontroller.serviceaccount.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: image-reflector-controller
 spec:
@@ -21,7 +23,7 @@ spec:
     spec:
       containers:
       - args:
-        - --events-addr=http://notification-controller/
+        - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json

--- a/charts/flux2/templates/kustomize-controller-crds.yaml
+++ b/charts/flux2/templates/kustomize-controller-crds.yaml
@@ -2,6 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/charts/flux2/templates/kustomize-controller-sa.yaml
+++ b/charts/flux2/templates/kustomize-controller-sa.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: kustomize-controller
   {{- with .Values.kustomizecontroller.serviceaccount.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: kustomize-controller
 spec:
@@ -21,7 +23,7 @@ spec:
     spec:
       containers:
       - args:
-        - --events-addr=http://notification-controller/
+        - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json

--- a/charts/flux2/templates/notification-controller-crds.yaml
+++ b/charts/flux2/templates/notification-controller-crds.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: alerts.notification.toolkit.fluxcd.io
 spec:
   group: notification.toolkit.fluxcd.io
@@ -210,6 +213,9 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -406,6 +412,9 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/charts/flux2/templates/notification-controller-sa.yaml
+++ b/charts/flux2/templates/notification-controller-sa.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: notification-controller
   {{- with .Values.notificationcontroller.serviceaccount.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/flux2/templates/notification-controller-service.yaml
+++ b/charts/flux2/templates/notification-controller-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: notification-controller
 spec:

--- a/charts/flux2/templates/notification-controller-webhook-service.yaml
+++ b/charts/flux2/templates/notification-controller-webhook-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: webhook-receiver
 spec:

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: notification-controller
 spec:

--- a/charts/flux2/templates/policies.yaml
+++ b/charts/flux2/templates/policies.yaml
@@ -2,6 +2,9 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: allow-egress
 spec:
   egress:
@@ -17,6 +20,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: allow-scraping
 spec:
   ingress:
@@ -32,6 +38,9 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: allow-webhooks
 spec:
   ingress:

--- a/charts/flux2/templates/source-controller-crds.yaml
+++ b/charts/flux2/templates/source-controller-crds.yaml
@@ -2,6 +2,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -229,6 +232,9 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -555,6 +561,9 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
@@ -806,6 +815,9 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   annotations:
     controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null

--- a/charts/flux2/templates/source-controller-service.yaml
+++ b/charts/flux2/templates/source-controller-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: source-controller
 spec:

--- a/charts/flux2/templates/source-controller-serviceaccount.yaml
+++ b/charts/flux2/templates/source-controller-serviceaccount.yaml
@@ -3,6 +3,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
   name: source-controller
   {{- with .Values.sourcecontroller.serviceaccount.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace }}
+    app.kubernetes.io/part-of: flux
     control-plane: controller
   name: source-controller
 spec:
@@ -23,7 +25,7 @@ spec:
     spec:
       containers:
       - args:
-        - --events-addr=http://notification-controller/
+        - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces
         - --log-level=info
         - --log-encoding=json

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -1,0 +1,70 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/part-of: flux
+        control-plane: controller
+      name: helm-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: helm-controller
+      template:
+        metadata:
+          annotations:
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app: helm-controller
+        spec:
+          containers:
+          - args:
+            - --events-addr=http://notification-controller/
+            - --watch-all-namespaces
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/helm-controller:v0.12.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
+          serviceAccountName: helm-controller
+          terminationGracePeriodSeconds: 600
+          volumes:
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -1,0 +1,72 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/part-of: flux
+        control-plane: controller
+      name: image-automation-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: image-automation-controller
+      template:
+        metadata:
+          annotations:
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app: image-automation-controller
+        spec:
+          containers:
+          - args:
+            - --events-addr=http://notification-controller/
+            - --watch-all-namespaces
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/image-automation-controller:v0.16.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
+          securityContext:
+            fsGroup: 1337
+          serviceAccountName: image-automation-controller
+          terminationGracePeriodSeconds: 10
+          volumes:
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -1,0 +1,76 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/part-of: flux
+        control-plane: controller
+      name: image-reflector-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: image-reflector-controller
+      template:
+        metadata:
+          annotations:
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app: image-reflector-controller
+        spec:
+          containers:
+          - args:
+            - --events-addr=http://notification-controller/
+            - --watch-all-namespaces
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/image-reflector-controller:v0.13.0
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
+            - mountPath: /data
+              name: data
+          securityContext:
+            fsGroup: 1337
+          serviceAccountName: image-reflector-controller
+          terminationGracePeriodSeconds: 10
+          volumes:
+          - emptyDir: {}
+            name: temp
+          - emptyDir: {}
+            name: data

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -1,0 +1,72 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/part-of: flux
+        control-plane: controller
+      name: kustomize-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: kustomize-controller
+      template:
+        metadata:
+          annotations:
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app: kustomize-controller
+        spec:
+          containers:
+          - args:
+            - --events-addr=http://notification-controller/
+            - --watch-all-namespaces
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/kustomize-controller:v0.16.0
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
+          securityContext:
+            fsGroup: 1337
+          serviceAccountName: kustomize-controller
+          terminationGracePeriodSeconds: 60
+          volumes:
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -1,0 +1,73 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/part-of: flux
+        control-plane: controller
+      name: notification-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: notification-controller
+      template:
+        metadata:
+          annotations:
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app: notification-controller
+        spec:
+          containers:
+          - args:
+            - --watch-all-namespaces
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/notification-controller:v0.18.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9090
+              name: http
+            - containerPort: 9292
+              name: http-webhook
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
+          serviceAccountName: notification-controller
+          terminationGracePeriodSeconds: 10
+          volumes:
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -1,0 +1,81 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/part-of: flux
+        control-plane: controller
+      name: source-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: source-controller
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          annotations:
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app: source-controller
+        spec:
+          containers:
+          - args:
+            - --events-addr=http://notification-controller/
+            - --watch-all-namespaces
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            - --storage-path=/data
+            - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/source-controller:v0.17.2
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9090
+              name: http
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+            readinessProbe:
+              httpGet:
+                path: /
+                port: http
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - mountPath: /data
+              name: data
+            - mountPath: /tmp
+              name: tmp
+          securityContext:
+            fsGroup: 1337
+          serviceAccountName: source-controller
+          terminationGracePeriodSeconds: 10
+          volumes:
+          - emptyDir: {}
+            name: data
+          - emptyDir: {}
+            name: tmp

--- a/charts/flux2/tests/helm-controller_test.yaml
+++ b/charts/flux2/tests/helm-controller_test.yaml
@@ -1,0 +1,24 @@
+suite: test helm-controller deployment
+templates:
+  - helm-controller.yaml
+tests:
+  - it: should be empty if source-controller is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+    set:
+      helmcontroller.create: false
+  - it: should have kind Deployment for k8s >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: { }

--- a/charts/flux2/tests/image-automation-controller_test.yaml
+++ b/charts/flux2/tests/image-automation-controller_test.yaml
@@ -1,0 +1,24 @@
+suite: test image-automation-controller deployment
+templates:
+  - image-automation-controller.yaml
+tests:
+  - it: should be empty if source-controller is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+    set:
+      imageautomationcontroller.create: false
+  - it: should have kind Deployment for k8s >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: { }

--- a/charts/flux2/tests/image-reflector-controller_test.yaml
+++ b/charts/flux2/tests/image-reflector-controller_test.yaml
@@ -1,0 +1,24 @@
+suite: test image-reflector-controller deployment
+templates:
+  - image-reflector-controller.yaml
+tests:
+  - it: should be empty if source-controller is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+    set:
+      imagereflectorcontroller.create: false
+  - it: should have kind Deployment for k8s >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: { }

--- a/charts/flux2/tests/kustomize-controller_test.yaml
+++ b/charts/flux2/tests/kustomize-controller_test.yaml
@@ -1,0 +1,24 @@
+suite: test kustomize-controller deployment
+templates:
+  - kustomize-controller.yaml
+tests:
+  - it: should be empty if source-controller is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+    set:
+      kustomizecontroller.create: false
+  - it: should have kind Deployment for k8s >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: { }

--- a/charts/flux2/tests/notification-controller_test.yaml
+++ b/charts/flux2/tests/notification-controller_test.yaml
@@ -1,0 +1,24 @@
+suite: test notification-controller deployment
+templates:
+  - notification-controller.yaml
+tests:
+  - it: should be empty if source-controller is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+    set:
+      notificationcontroller.create: false
+  - it: should have kind Deployment for k8s >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: { }

--- a/charts/flux2/tests/source-controller_test.yaml
+++ b/charts/flux2/tests/source-controller_test.yaml
@@ -1,0 +1,24 @@
+suite: test source-controller deployment
+templates:
+  - source-controller.yaml
+tests:
+  - it: should be empty if source-controller is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+    set:
+      sourcecontroller.create: false
+  - it: should have kind Deployment for k8s >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: { }

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -8,7 +8,7 @@ installCRDs: true
 # In such environments they normally add `.cluster.local` and `.local`
 # suffixes to `no_proxy` variable in order to prevent cluster-local
 # traffic from going through http proxy. Without fully specified
-# domain they need to mention `notifications-controller` explicity in
+# domain they need to mention `notifications-controller` explicitly in
 # `no_proxy` variable after debugging http proxy logs
 # eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN]
 eventsaddr: http://notification-controller/

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -4,7 +4,7 @@ installCRDs: true
 
 # -- Maybe you need to use full domain name here, if you deploy flux
 # in environments that use http proxy.
-# 
+#
 # In such environments they normally add `.cluster.local` and `.local`
 # suffixes to `no_proxy` variable in order to prevent cluster-local
 # traffic from going through http proxy. Without fully specified

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -1,4 +1,20 @@
+# global
+
 installCRDs: true
+
+# -- Maybe you need to use full domain name here, if you deploy flux
+# in environments that use http proxy.
+# 
+# In such environments they normally add `.cluster.local` and `.local`
+# suffixes to `no_proxy` variable in order to prevent cluster-local
+# traffic from going through http proxy. Without fully specified
+# domain they need to mention `notifications-controller` explicity in
+# `no_proxy` variable after debugging http proxy logs
+# eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN]
+eventsaddr: http://notification-controller/
+
+
+# controllers
 
 helmcontroller:
   create: true
@@ -43,7 +59,7 @@ helmcontroller:
 imageautomationcontroller:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v0.16.0
+  tag: v0.16.1
   resources:
     limits:
       cpu: 1000m
@@ -138,7 +154,7 @@ notificationcontroller:
 sourcecontroller:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v0.17.1
+  tag: v0.17.2
   resources:
     limits:
       cpu: 1000m

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,3 +4,5 @@ target-branch: main
 chart-dirs:
   - charts
 validate-maintainers: false
+additional-commands:
+  - helm unittest --helm3 --strict --file tests/*.yaml --file 'tests/**/*.yaml' {{ .Path }}


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

  - updates chart to support flux 0.21.1
    - add new labels like in flux upstream manifestgen: https://github.com/fluxcd/flux2/pull/2036
    - make eventsaddr configurable to math https://github.com/fluxcd/flux2/pull/2046
    - match https://github.com/fluxcd/flux2/pull/2051
  - adds basic unittests
  - add bug and feature report templates for github

#### Special notes for your reviewer:

This is a rather big change. Sorry for that. You can ignore the files in \_\_snapshot\_\_, because these are autogenerate files by by helm unittest.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [ ] Helm chart is tested