### PR TITLE
Fix bug in secretRef value

### DIFF
--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: flux2-sync
-version: "0.3.0"
+version: "0.3.1"
 
 description: A Helm chart for flux2 GitRepository to sync with
 sources:

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 

--- a/charts/flux2-sync/templates/gitrepository.yaml
+++ b/charts/flux2-sync/templates/gitrepository.yaml
@@ -14,7 +14,7 @@ spec:
   secretRef:
     name: {{ .Release.Namespace }}
   {{- else if .Values.gitRepository.spec.secretRef }}
-  secretRef: {{ toYaml . | nindent 4 }}
+  secretRef: {{ toYaml .Values.gitRepository.spec.secretRef | nindent 4 }}
   {{- end }}
   {{- if .Values.gitRepository.spec.interval }}
   interval: {{ .Values.gitRepository.spec.interval }}

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-0.3.0
+        helm.sh/chart: flux2-sync-0.3.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque


### PR DESCRIPTION
#### What this PR does / why we need it:
Current flux2-sync (0.3.0) chart throws error if you specify a `gitRepository.spec.secretRef.name` value and `secret.create` is set to false.

helm error message:
```sh
helm upgrade --install flux2-sync fluxcd-community/flux2-sync -n default -f values.yaml
Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(GitRepository.spec.secretRef): unknown field "Capabilities" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef, ValidationError(GitRepository.spec.secretRef): unknown field "Chart" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef, ValidationError(GitRepository.spec.secretRef): unknown field "Files" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef, ValidationError(GitRepository.spec.secretRef): unknown field "Release" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef, ValidationError(GitRepository.spec.secretRef): unknown field "Subcharts" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef, ValidationError(GitRepository.spec.secretRef): unknown field "Template" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef, ValidationError(GitRepository.spec.secretRef): unknown field "Values" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef, ValidationError(GitRepository.spec.secretRef): missing required field "name" in io.fluxcd.toolkit.source.v1beta1.GitRepository.spec.secretRef]
```

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested