### PR TITLE
add envFrom to kustomize-controller to get configMap and/or secret

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -48,3 +48,7 @@ jobs:
       - name: Run chart-testing (install) for flux2
         run: ct install --config ct.yaml --charts charts/flux2
         if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install) for flux2-sync
+        run: ct install --config ct.yaml --charts charts/flux2-sync
+        if: steps.list-changed.outputs.changed == 'true'

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: flux2-sync
-version: "0.3.2"
+version: "0.3.3"
 
 description: A Helm chart for flux2 GitRepository to sync with
 sources:

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-0.3.2
+        helm.sh/chart: flux2-sync-0.3.3
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/tests/secret_test.yaml
+++ b/charts/flux2-sync/tests/secret_test.yaml
@@ -24,7 +24,7 @@ tests:
           of: Secret
       - isAPIVersion:
           of: v1
-  - it: should match snapshot of default values
+  - it: should match snapshot
     asserts:
       - matchSnapshot: {}
     set:

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -3,6 +3,6 @@ name: flux2
 description: A Helm chart for flux2
 
 type: application
-version: "0.7.1"
+version: "0.7.2"
 
 appVersion: "0.24.0"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -64,6 +64,7 @@ A Helm chart for flux2
 | kustomizecontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | kustomizecontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | kustomizecontroller.create | bool | `true` |  |
+| kustomizecontroller.envFrom | object | `{"map":{"name":""},"secret":{"name":""}}` | Defines envFrom using a configmap and/or secret. |
 | kustomizecontroller.extraSecretMounts | list | `[]` | Defines additional mounts with secrets. Secrets must be manually created in the namespace or with kustomizecontroller.secret |
 | kustomizecontroller.image | string | `"ghcr.io/fluxcd/kustomize-controller"` |  |
 | kustomizecontroller.labels | object | `{}` |  |
@@ -72,7 +73,7 @@ A Helm chart for flux2
 | kustomizecontroller.resources.limits.memory | string | `"1Gi"` |  |
 | kustomizecontroller.resources.requests.cpu | string | `"100m"` |  |
 | kustomizecontroller.resources.requests.memory | string | `"64Mi"` |  |
-| kustomizecontroller.secret.create | bool | `false` | Create a secret to use it with extraSecretMounts. Defaults to false. |
+| kustomizecontroller.secret.create | bool | `false` | Create a secret to use it with extraSecretMounts or envForm. Defaults to false. |
 | kustomizecontroller.secret.data | object | `{}` |  |
 | kustomizecontroller.secret.name | string | `""` |  |
 | kustomizecontroller.serviceaccount.annotations | object | `{}` |  |

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -36,6 +36,17 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if or (.Values.kustomizecontroller.envFrom.map.name) (.Values.kustomizecontroller.envFrom.secret.name) }}
+        envFrom:
+          {{- if .Values.kustomizecontroller.envFrom.map.name }}
+          - configMapRef:
+              name: {{ .Values.kustomizecontroller.envFrom.map.name }}
+          {{- end }}
+          {{- if .Values.kustomizecontroller.envFrom.secret.name }}
+          - secretRef:
+              name: {{ .Values.kustomizecontroller.envFrom.secret.name }}
+          {{- end }}
+        {{- end }}
         image: {{ .Values.kustomizecontroller.image }}:{{ .Values.kustomizecontroller.tag }}
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.0
         control-plane: controller
-        helm.sh/chart: flux2-0.7.1
+        helm.sh/chart: flux2-0.7.2
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.0
         control-plane: controller
-        helm.sh/chart: flux2-0.7.1
+        helm.sh/chart: flux2-0.7.2
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.0
         control-plane: controller
-        helm.sh/chart: flux2-0.7.1
+        helm.sh/chart: flux2-0.7.2
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.0
-        helm.sh/chart: flux2-0.7.1
+        helm.sh/chart: flux2-0.7.2
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.0
         control-plane: controller
-        helm.sh/chart: flux2-0.7.1
+        helm.sh/chart: flux2-0.7.2
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.0
         control-plane: controller
-        helm.sh/chart: flux2-0.7.1
+        helm.sh/chart: flux2-0.7.2
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.0
         control-plane: controller
-        helm.sh/chart: flux2-0.7.1
+        helm.sh/chart: flux2-0.7.2
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -125,10 +125,16 @@ kustomizecontroller:
     create: true
     annotations: {}
   secret:
-    # -- Create a secret to use it with extraSecretMounts. Defaults to false.
+    # -- Create a secret to use it with extraSecretMounts or envForm. Defaults to false.
     create: false
     name: ""
     data: {}
+  # -- Defines envFrom using a configmap and/or secret.
+  envFrom:
+    map:
+      name: ""
+    secret:
+      name: ""
   # -- Defines additional mounts with secrets.
   # Secrets must be manually created in the namespace or with kustomizecontroller.secret
   extraSecretMounts: []


### PR DESCRIPTION
Signed-off-by: Daniel Werdermann <daniel.werdermann@gmail.com>

<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

  - Allow for the ability to specify envFrom values for the kustomize controller

#### Which issue this PR fixes

  - fixes #35 
  - it implements the code of the closed PR #36

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested