### PR TITLE
chore: update Makefile and Readme

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,3 +25,4 @@ We would like these checks to pass before we even continue reviewing your change
 - [ ] Chart Version bumped
 - [ ] helm-docs are updated
 - [ ] Helm chart is tested
+- [ ] Run `make reviewable`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
       name: helmdocs
       entry: make helmdocs
       language: system
+    - id: reviewable
+      name: reviewable
+      entry: make reviewable
+      language: system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,9 @@ Once changes have been merged, the release job will automatically run to package
 * run: ```helm unittest --helm3 --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2/```
     * add ```-u``` if you need to update the compare snapshot in \_\_snapshots\_\_
 * bump chart version if necessary
-* run: ```helm-docs```
+* run: ```make helmdocs```
 * squash all commits
+* run: `make reviewable`
 
 ### Immutability
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Release Charts](https://github.com/fluxcd-community/helm-charts/workflows/Release%20Charts/badge.svg?branch=main)
 
+These helm charts are maintained and released by the fluxcd-community on a best effort basis.
+
 ## Usage
 
 [Helm](https://helm.sh) must be installed to use the charts.

--- a/_readme_templates.gotmpl
+++ b/_readme_templates.gotmpl
@@ -1,0 +1,18 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+This helm chart is maintain and released by the fluxcd-community on a best effort basis.
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/flux2-multi-tenancy/Chart.yaml
+++ b/charts/flux2-multi-tenancy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: flux2-multi-tenancy
-version: 0.0.2
+version: 0.0.3
 description: A Helm chart for flux2-multi-tenancy
 sources:
   - https://github.com/fluxcd/flux2-multi-tenancy

--- a/charts/flux2-multi-tenancy/README.md
+++ b/charts/flux2-multi-tenancy/README.md
@@ -1,8 +1,10 @@
 # flux2-multi-tenancy
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for flux2-multi-tenancy
+
+This helm chart is maintain and released by the fluxcd-community on a best effort basis.
 
 ## Source Code
 
@@ -24,4 +26,3 @@ A Helm chart for flux2-multi-tenancy
 | policy.rules.serviceAccountName.exclude.namespaces | list | `["flux-system"]` | List of namestace to ignore. |
 | policy.rules.serviceAccountName.match.kinds | list | `["Kustomization","HelmRelease"]` | The `Kinds` we want to check that a serviceAccountName is set |
 | policy.validationFailureAction | string | `"enforce"` | Tells Kyverno if the resource being validated should be allowed but reported (`audit`) or blocked (`enforce`). |
-

--- a/charts/flux2-multi-tenancy/tests/__snapshot__/kyverno-policy_test.yaml.snap
+++ b/charts/flux2-multi-tenancy/tests/__snapshot__/kyverno-policy_test.yaml.snap
@@ -1,0 +1,74 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      annotations:
+        helm.sh/hook: post-install
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: flux
+        helm.sh/chart: flux2-multi-tenancy-0.0.3
+      name: RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      rules:
+      - exclude:
+          resources:
+            namespaces:
+            - flux-system
+        match:
+          resources:
+            kinds:
+            - Kustomization
+            - HelmRelease
+        name: serviceAccountName
+        validate:
+          message: .spec.serviceAccountName is required
+          pattern:
+            spec:
+              serviceAccountName: ?*
+      - exclude:
+          resources:
+            namespaces:
+            - flux-system
+        match:
+          resources:
+            kinds:
+            - Kustomization
+        name: kustomizationSourceRefNamespace
+        preconditions:
+          any:
+          - key: '{{request.object.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: ""
+        validate:
+          deny:
+            conditions:
+            - key: '{{request.object.spec.sourceRef.namespace}}'
+              operator: NotEquals
+              value: '{{request.object.metadata.namespace}}'
+          message: .spec.sourceRef.namespace must be the same as metadata.namespace
+      - exclude:
+          resources:
+            namespaces:
+            - flux-system
+        match:
+          resources:
+            kinds:
+            - HelmRelease
+        name: helmReleaseSourceRefNamespace
+        preconditions:
+          any:
+          - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: ""
+        validate:
+          deny:
+            conditions:
+            - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+              operator: NotEquals
+              value: '{{request.object.metadata.namespace}}'
+          message: .spec.chart.spec.sourceRef.namespace must be the same as metadata.namespace
+      validationFailureAction: enforce

--- a/charts/flux2-multi-tenancy/tests/kyverno-policy_test.yaml
+++ b/charts/flux2-multi-tenancy/tests/kyverno-policy_test.yaml
@@ -1,0 +1,18 @@
+suite: test kyverno deployment
+templates:
+  - kyverno-policy.yaml
+tests:
+  - it: should have kind Secret for k8s >= 1.19
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterPolicy
+      - isAPIVersion:
+          of: kyverno.io/v1
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: {}

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: flux2-sync
-version: "0.3.5"
+version: 0.3.6
 
 description: A Helm chart for flux2 GitRepository to sync with
 sources:

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,8 +1,10 @@
 # flux2-sync
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
+
+This helm chart is maintain and released by the fluxcd-community on a best effort basis.
 
 ## Source Code
 
@@ -43,4 +45,3 @@ A Helm chart for flux2 GitRepository to sync with
 | kustomizationlist | object | `{}` | (Optional) If you want multiple subdirectories which depend on each other in the same repo. Their name is derived from their path. |
 | secret.create | bool | `false` | Create a secret for the git repository. Defaults to false. |
 | secret.data | object | `{}` | Data of the secret. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields. Values will be encoded to base64 by the helm chart. |
-

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-0.3.5
+        helm.sh/chart: flux2-sync-0.3.6
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,5 +2,7 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: 0.24.1
+sources:
+  - https://github.com/fluxcd-community/helm-charts

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,8 +1,14 @@
 # flux2
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
+![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
 
 A Helm chart for flux2
+
+This helm chart is maintain and released by the fluxcd-community on a best effort basis.
+
+## Source Code
+
+* <https://github.com/fluxcd-community/helm-charts>
 
 ## Values
 
@@ -115,4 +121,3 @@ A Helm chart for flux2
 | sourcecontroller.tag | string | `"v0.19.2"` |  |
 | sourcecontroller.tolerations | list | `[]` |  |
 | watchallnamespaces | bool | `true` |  |
-

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.2
+        helm.sh/chart: flux2-0.8.3
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.2
+        helm.sh/chart: flux2-0.8.3
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.2
+        helm.sh/chart: flux2-0.8.3
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
-        helm.sh/chart: flux2-0.8.2
+        helm.sh/chart: flux2-0.8.3
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.2
+        helm.sh/chart: flux2-0.8.3
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.2
+        helm.sh/chart: flux2-0.8.3
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.2
+        helm.sh/chart: flux2-0.8.3
       name: source-controller
     spec:
       replicas: 1

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -
 
 TEMPDIR=$(mktemp -d tmp.generate.XXXXX)
+
 delete_temp_dir() {
     if [ -d "${TEMPDIR}" ]; then
         rm -r "${TEMPDIR}"
@@ -8,8 +9,8 @@ delete_temp_dir() {
 }
 trap delete_temp_dir EXIT
 
-for FILE in `cat .work/flux2/manifests/crds/kustomization.yaml | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*"` 
-do 
+for FILE in `cat .work/flux2/manifests/crds/kustomization.yaml | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*"`
+do
 
 cat <<EOF > "${TEMPDIR}/global-labels.yaml"
 apiVersion: builtin
@@ -36,11 +37,9 @@ transformers:
    - global-labels.yaml
 EOF
 
-kustomize build "${TEMPDIR}" > ./charts/flux2/templates/${FILE##*/}
+kubectl kustomize "${TEMPDIR}" > ./charts/flux2/templates/${FILE##*/}
 echo -e "{{- if .Values.installCRDs }}\n$(cat ./charts/flux2/templates/${FILE##*/})" > ./charts/flux2/templates/${FILE##*/}
 echo -e "$(cat ./charts/flux2/templates/${FILE##*/})\n{{- end }}" > ./charts/flux2/templates/${FILE##*/}
 
 
 done
-
-app_version=$(cat Makefile | grep "FLUX2_VERSION ?= " | cut -c19-) yq e -i '.appVersion = env(app_version)' ./charts/flux2/Chart.yaml


### PR DESCRIPTION
Signed-off-by: Daniel Werdermann <daniel.werdermann@gmail.com>

#### What this PR does / why we need it:
 - Add unittest for flux2-multi-tenancy chart
 - Add _readme_templates.gotmpl to adjust generated READMEs, and add hint, that the charts are community driven. 
 - Extend Makefile, so you can run `make reviewable` and see if everything is fine before opening the PR

#### Which issue this PR fixes
  - fixes #27 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested