### PR TITLE
support setting of imagePullSecrets for all controllers #53

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: 0.24.1
 sources:
   - https://github.com/fluxcd-community/helm-charts

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
+![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -35,6 +35,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmcontroller.serviceaccount.create | bool | `true` |  |
 | helmcontroller.tag | string | `"v0.14.1"` |  |
 | helmcontroller.tolerations | list | `[]` |  |
+| imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageautomationcontroller.affinity | object | `{}` |  |
 | imageautomationcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | imageautomationcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -74,6 +74,9 @@ spec:
         {{- toYaml .Values.helmcontroller.volumeMounts | nindent 8 }}
         {{- end}}
       serviceAccountName: helm-controller
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -76,6 +76,9 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: image-automation-controller
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - emptyDir: {}

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -78,6 +78,9 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: image-reflector-controller
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - emptyDir: {}

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -93,6 +93,9 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: kustomize-controller
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       volumes:
       - emptyDir: {}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -77,6 +77,9 @@ spec:
         {{- toYaml .Values.notificationcontroller.volumeMounts | nindent 8 }}
         {{- end}}
       serviceAccountName: notification-controller
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - emptyDir: {}

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -83,6 +83,9 @@ spec:
       securityContext:
         fsGroup: 1337
       serviceAccountName: source-controller
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       volumes:
       - emptyDir: {}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.3
+        helm.sh/chart: flux2-0.8.4
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.3
+        helm.sh/chart: flux2-0.8.4
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.3
+        helm.sh/chart: flux2-0.8.4
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
-        helm.sh/chart: flux2-0.8.3
+        helm.sh/chart: flux2-0.8.4
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.3
+        helm.sh/chart: flux2-0.8.4
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.3
+        helm.sh/chart: flux2-0.8.4
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.3
+        helm.sh/chart: flux2-0.8.4
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -205,3 +205,6 @@ rbac:
   create: true
 
 watchallnamespaces: true
+
+# -- contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers
+imagePullSecrets: []


### PR DESCRIPTION
Example helm cli usage to provide an imagePullSecret

```
helm ... --set "imagePullSecrets[0].name=secret1"
```

Signed-off-by: Robert R Allen <robert.r.allen@ericsson.com>

<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

The flux CLI supports customizing the imagePullSecrets. This brings equivalent behavior to the helm chart.

#### Which issue this PR fixes
  - partially implements #53 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
