### PR TITLE
made replicas optionally editable ...

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 0.8.4
+version: 0.8.5
 appVersion: 0.24.1
 sources:
   - https://github.com/fluxcd-community/helm-charts

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
+![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -87,6 +87,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizecontroller.serviceaccount.create | bool | `true` |  |
 | kustomizecontroller.tag | string | `"v0.18.2"` |  |
 | kustomizecontroller.tolerations | list | `[]` |  |
+| loglevel | string | `"info"` |  |
 | notificationcontroller.affinity | object | `{}` |  |
 | notificationcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | notificationcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -11,7 +11,11 @@ metadata:
     control-plane: controller
   name: helm-controller
 spec:
+  {{- if kindIs "invalid" .Values.helmcontroller.replicas }}
   replicas: 1
+  {{- else }}
+  replicas: {{ .Values.helmcontroller.replicas  }}
+  {{- end}}
   selector:
     matchLabels:
       app: helm-controller
@@ -32,7 +36,7 @@ spec:
       - args:
         - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces={{ .Values.watchallnamespaces }}
-        - --log-level=info
+        - --log-level={{ .Values.loglevel | default "info" }}
         - --log-encoding=json
         - --enable-leader-election
         env:

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -11,7 +11,11 @@ metadata:
     control-plane: controller
   name: image-automation-controller
 spec:
+  {{- if kindIs "invalid" .Values.imageautomationcontroller.replicas }}
   replicas: 1
+  {{- else }}
+  replicas: {{ .Values.imageautomationcontroller.replicas  }}
+  {{- end}}
   selector:
     matchLabels:
       app: image-automation-controller
@@ -32,7 +36,7 @@ spec:
       - args:
         - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces={{ .Values.watchallnamespaces }}
-        - --log-level=info
+        - --log-level={{ .Values.loglevel | default "info" }}
         - --log-encoding=json
         - --enable-leader-election
         env:

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -11,7 +11,11 @@ metadata:
     control-plane: controller
   name: image-reflector-controller
 spec:
+  {{- if kindIs "invalid" .Values.imagereflectorcontroller.replicas }}
   replicas: 1
+  {{- else }}
+  replicas: {{ .Values.imagereflectorcontroller.replicas  }}
+  {{- end}}
   selector:
     matchLabels:
       app: image-reflector-controller
@@ -32,7 +36,7 @@ spec:
       - args:
         - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces={{ .Values.watchallnamespaces }}
-        - --log-level=info
+        - --log-level={{ .Values.loglevel | default "info" }}
         - --log-encoding=json
         - --enable-leader-election
         env:

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -11,7 +11,11 @@ metadata:
     control-plane: controller
   name: kustomize-controller
 spec:
+  {{- if kindIs "invalid" .Values.kustomizecontroller.replicas }}
   replicas: 1
+  {{- else }}
+  replicas: {{ .Values.kustomizecontroller.replicas  }}
+  {{- end}}
   selector:
     matchLabels:
       app: kustomize-controller
@@ -32,7 +36,7 @@ spec:
       - args:
         - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces={{ .Values.watchallnamespaces }}
-        - --log-level=info
+        - --log-level={{ .Values.loglevel | default "info" }}
         - --log-encoding=json
         - --enable-leader-election
         env:

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -11,7 +11,11 @@ metadata:
     control-plane: controller
   name: notification-controller
 spec:
+  {{- if kindIs "invalid" .Values.notificationcontroller.replicas }}
   replicas: 1
+  {{- else }}
+  replicas: {{ .Values.notificationcontroller.replicas  }}
+  {{- end}}
   selector:
     matchLabels:
       app: notification-controller
@@ -31,7 +35,7 @@ spec:
       containers:
       - args:
         - --watch-all-namespaces={{ .Values.watchallnamespaces }}
-        - --log-level=info
+        - --log-level={{ .Values.loglevel | default "info" }}
         - --log-encoding=json
         - --enable-leader-election
         env:

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -11,7 +11,11 @@ metadata:
     control-plane: controller
   name: source-controller
 spec:
+  {{- if kindIs "invalid" .Values.sourcecontroller.replicas }}
   replicas: 1
+  {{- else }}
+  replicas: {{ .Values.sourcecontroller.replicas  }}
+  {{- end}}
   selector:
     matchLabels:
       app: source-controller
@@ -34,7 +38,7 @@ spec:
       - args:
         - --events-addr={{ .Values.eventsaddr }}
         - --watch-all-namespaces={{ .Values.watchallnamespaces }}
-        - --log-level=info
+        - --log-level={{ .Values.loglevel | default "info" }}
         - --log-encoding=json
         - --enable-leader-election
         - --storage-path=/data

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.4
+        helm.sh/chart: flux2-0.8.5
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.4
+        helm.sh/chart: flux2-0.8.5
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.4
+        helm.sh/chart: flux2-0.8.5
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
-        helm.sh/chart: flux2-0.8.4
+        helm.sh/chart: flux2-0.8.5
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.4
+        helm.sh/chart: flux2-0.8.5
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.4
+        helm.sh/chart: flux2-0.8.5
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.24.1
         control-plane: controller
-        helm.sh/chart: flux2-0.8.4
+        helm.sh/chart: flux2-0.8.5
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -204,6 +204,7 @@ policies:
 rbac:
   create: true
 
+loglevel: info
 watchallnamespaces: true
 
 # -- contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers


### PR DESCRIPTION
… and added loglevel option.

Signed-off-by: Kevin De Keyser <k.dekeyser@mwam.com>

#### What this PR does / why we need it:
Added optional replicas field. This is useful for scaling down the deployment to 0 pods when migrating fluxv2 and in the future for updating fluxv2 to fluxv3.
Added optional loglevel field so it can be set to debug when deployed, else info is used.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Run `make reviewable`
