### PR TITLE
chore: add update.chartversion Makefile and help

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -41,5 +41,9 @@ kubectl kustomize "${TEMPDIR}" > ./charts/flux2/templates/${FILE##*/}
 echo -e "{{- if .Values.installCRDs }}\n$(cat ./charts/flux2/templates/${FILE##*/})" > ./charts/flux2/templates/${FILE##*/}
 echo -e "$(cat ./charts/flux2/templates/${FILE##*/})\n{{- end }}" > ./charts/flux2/templates/${FILE##*/}
 
+# git diff --quiet will exit 1 when there are changes.
+if ! git diff --quiet HEAD main -- ./charts/flux2/templates/ ; then
+  make update.chartversion chartyamlpath=./charts/flux2/Chart.yaml semvertype=minor
+fi
 
 done


### PR DESCRIPTION
Signed-off-by: Daniel Werdermann <daniel.werdermann@gmail.com>

#### What this PR does / why we need it:
  - `make generate` will also bump chart version if needed.
  - Add `make help`

#### Which issue this PR fixes
  - fixes #48 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] helm-docs are updated
- [ ] Helm chart is tested
- [x] Run `make reviewable`
