### PR TITLE
feat(v0.25.3): bump for upstream release flux2 to v0.25.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v0.24.1
+FLUX2_VERSION ?= v0.25.3
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 0.8.6
-appVersion: 0.24.1
+version: 0.9.0
+appVersion: 0.25.3
 sources:
   - https://github.com/fluxcd-community/helm-charts

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.25.3](https://img.shields.io/badge/AppVersion-0.25.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -17,7 +17,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v0.24.1"` |  |
+| cli.tag | string | `"v0.25.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy. In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
 | helmcontroller.affinity | object | `{}` |  |
@@ -33,7 +33,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | helmcontroller.serviceaccount.annotations | object | `{}` |  |
 | helmcontroller.serviceaccount.create | bool | `true` |  |
-| helmcontroller.tag | string | `"v0.14.1"` |  |
+| helmcontroller.tag | string | `"v0.15.0"` |  |
 | helmcontroller.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageautomationcontroller.affinity | object | `{}` |  |
@@ -49,7 +49,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageautomationcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | imageautomationcontroller.serviceaccount.annotations | object | `{}` |  |
 | imageautomationcontroller.serviceaccount.create | bool | `true` |  |
-| imageautomationcontroller.tag | string | `"v0.18.0"` |  |
+| imageautomationcontroller.tag | string | `"v0.19.0"` |  |
 | imageautomationcontroller.tolerations | list | `[]` |  |
 | imagereflectorcontroller.affinity | object | `{}` |  |
 | imagereflectorcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -64,7 +64,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imagereflectorcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | imagereflectorcontroller.serviceaccount.annotations | object | `{}` |  |
 | imagereflectorcontroller.serviceaccount.create | bool | `true` |  |
-| imagereflectorcontroller.tag | string | `"v0.14.0"` |  |
+| imagereflectorcontroller.tag | string | `"v0.15.0"` |  |
 | imagereflectorcontroller.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizecontroller.affinity | object | `{}` |  |
@@ -85,7 +85,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizecontroller.secret.name | string | `""` |  |
 | kustomizecontroller.serviceaccount.annotations | object | `{}` |  |
 | kustomizecontroller.serviceaccount.create | bool | `true` |  |
-| kustomizecontroller.tag | string | `"v0.18.2"` |  |
+| kustomizecontroller.tag | string | `"v0.19.1"` |  |
 | kustomizecontroller.tolerations | list | `[]` |  |
 | loglevel | string | `"info"` |  |
 | notificationcontroller.affinity | object | `{}` |  |
@@ -102,7 +102,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationcontroller.service.labels | object | `{}` |  |
 | notificationcontroller.serviceaccount.annotations | object | `{}` |  |
 | notificationcontroller.serviceaccount.create | bool | `true` |  |
-| notificationcontroller.tag | string | `"v0.19.0"` |  |
+| notificationcontroller.tag | string | `"v0.20.1"` |  |
 | notificationcontroller.tolerations | list | `[]` |  |
 | policies.create | bool | `true` |  |
 | rbac.create | bool | `true` |  |
@@ -110,6 +110,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourcecontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | sourcecontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | sourcecontroller.create | bool | `true` |  |
+| sourcecontroller.extraEnv | list | `[]` |  |
 | sourcecontroller.image | string | `"ghcr.io/fluxcd/source-controller"` |  |
 | sourcecontroller.labels | object | `{}` |  |
 | sourcecontroller.nodeSelector | object | `{}` |  |
@@ -120,7 +121,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourcecontroller.service.labels | object | `{}` |  |
 | sourcecontroller.serviceaccount.annotations | object | `{}` |  |
 | sourcecontroller.serviceaccount.create | bool | `true` |  |
-| sourcecontroller.tag | string | `"v0.19.2"` |  |
+| sourcecontroller.tag | string | `"v0.20.1"` |  |
 | sourcecontroller.tolerations | list | `[]` |  |
-| sourcecontroller.extraEnv | list | `[]` |  |
 | watchallnamespaces | bool | `true` |  |

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
@@ -122,8 +122,6 @@ spec:
             - policy
             type: object
           status:
-            default:
-              observedGeneration: -1
             description: ImagePolicyStatus defines the observed state of ImagePolicy
             properties:
               conditions:
@@ -202,7 +200,6 @@ spec:
                   the policy.
                 type: string
               observedGeneration:
-                description: ObservedGeneration is the last reconciled generation.
                 format: int64
                 type: integer
             type: object
@@ -503,6 +500,8 @@ spec:
             - policy
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: ImagePolicyStatus defines the observed state of ImagePolicy
             properties:
               conditions:
@@ -600,7 +599,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
@@ -691,8 +690,6 @@ spec:
                 type: string
             type: object
           status:
-            default:
-              observedGeneration: -1
             description: ImageRepositoryStatus defines the observed state of ImageRepository
             properties:
               canonicalImageName:
@@ -1058,6 +1055,8 @@ spec:
                 type: string
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: ImageRepositoryStatus defines the observed state of ImageRepository
             properties:
               canonicalImageName:

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
@@ -218,7 +218,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
@@ -425,7 +425,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.24.1
+        app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.8.6
+        helm.sh/chart: flux2-0.9.0
       name: helm-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/helm-controller:v0.14.1
+            image: ghcr.io/fluxcd/helm-controller:v0.15.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.24.1
+        app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.8.6
+        helm.sh/chart: flux2-0.9.0
       name: image-automation-controller
     spec:
       replicas: 1
@@ -36,7 +36,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/image-automation-controller:v0.18.0
+            image: ghcr.io/fluxcd/image-automation-controller:v0.19.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.24.1
+        app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.8.6
+        helm.sh/chart: flux2-0.9.0
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -36,7 +36,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/image-reflector-controller:v0.14.0
+            image: ghcr.io/fluxcd/image-reflector-controller:v0.15.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.24.1
-        helm.sh/chart: flux2-0.8.6
+        app.kubernetes.io/version: 0.25.3
+        helm.sh/chart: flux2-0.9.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.24.1
+        app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.8.6
+        helm.sh/chart: flux2-0.9.0
       name: kustomize-controller
     spec:
       replicas: 1
@@ -36,7 +36,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/kustomize-controller:v0.18.2
+            image: ghcr.io/fluxcd/kustomize-controller:v0.19.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.24.1
+        app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.8.6
+        helm.sh/chart: flux2-0.9.0
       name: notification-controller
     spec:
       replicas: 1
@@ -35,7 +35,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/notification-controller:v0.19.0
+            image: ghcr.io/fluxcd/notification-controller:v0.20.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.24.1
+        app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.8.6
+        helm.sh/chart: flux2-0.9.0
       name: source-controller
     spec:
       replicas: 1
@@ -40,7 +40,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/source-controller:v0.19.2
+            image: ghcr.io/fluxcd/source-controller:v0.20.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -15,7 +15,7 @@ eventsaddr: http://notification-controller/
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v0.24.1
+  tag: v0.25.3
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -25,7 +25,7 @@ cli:
 helmcontroller:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v0.14.1
+  tag: v0.15.0
   resources:
     limits:
       cpu: 1000m
@@ -67,7 +67,7 @@ helmcontroller:
 imageautomationcontroller:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v0.18.0
+  tag: v0.19.0
   resources:
     limits:
       cpu: 1000m
@@ -89,7 +89,7 @@ imageautomationcontroller:
 imagereflectorcontroller:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v0.14.0
+  tag: v0.15.0
   resources:
     limits:
       cpu: 1000m
@@ -111,7 +111,7 @@ imagereflectorcontroller:
 kustomizecontroller:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v0.18.2
+  tag: v0.19.1
   resources:
     limits:
       cpu: 1000m
@@ -153,7 +153,7 @@ kustomizecontroller:
 notificationcontroller:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v0.19.0
+  tag: v0.20.1
   resources:
     limits:
       cpu: 1000m
@@ -177,7 +177,7 @@ notificationcontroller:
 sourcecontroller:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v0.19.2
+  tag: v0.20.1
   resources:
     limits:
       cpu: 1000m


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
update to flux2 upstream v0.25.3 release
https://github.com/fluxcd/flux2/releases/tag/v0.25.3

#### Special notes for your reviewer:
`This will be the last version where flux2 upstream support Kubernetes 1.19 and older. Next release will drop all EOL versions and it will come with a restricted pod security profile.`

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Run `make reviewable`
