### PR TITLE
feat(flux2): Added ability to deploy extra K8s manifests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,4 +25,5 @@ We would like these checks to pass before we even continue reviewing your change
 - [ ] Chart Version bumped
 - [ ] helm-docs are updated
 - [ ] Helm chart is tested
+- [ ] Update artifacthub.io/changes in Chart.yaml
 - [ ] Run `make reviewable`

--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,9 @@ update.appversion:
 		chartname=$$(cat ./charts/$${file}/Chart.yaml | grep -E '^name: ' | cut -c7-) ; \
 		$(INFO) Update chartname and chartversion string in test snapshots for $${file}.; \
 		sed -s -i "s/^\([[:space:]]\+helm\.sh\/chart:\).*/\1 $${chartname}-$${chartversion}/" ./charts/$${file}/tests/__snapshot__/*.yaml.snap ; \
-        sed -s -i "s/^\([[:space:]]\+app\.kubernetes\.io\/version:\).*/\1 $(subst v,,${FLUX2_VERSION})/" ./charts/$${file}/tests/__snapshot__/*.yaml.snap ; \
+		sed -s -i "s/^\([[:space:]]\+app\.kubernetes\.io\/version:\).*/\1 $(subst v,,${FLUX2_VERSION})/" ./charts/$${file}/tests/__snapshot__/*.yaml.snap ; \
 		$(INFO) Update appVersion in ./charts/$${file}/Chart.yaml ;\
-        sed -s -i "s/^\(appVersion:\).*/\1 $(subst v,,${FLUX2_VERSION})/" ./charts/$${file}/Chart.yaml ; \
+		sed -s -i "s/^\(appVersion:\).*/\1 $(subst v,,${FLUX2_VERSION})/" ./charts/$${file}/Chart.yaml ; \
 		$(OK) "Version strings updated" ; \
 	done
 
@@ -139,7 +139,7 @@ Targets:
     helmdocs              Update README.md files in chart directories.
     unittests             Run helm unittest against the charts.
     update.appversion     Update version strings in testfiles and Chart.yaml.
-	update.chartversion   Bump Semver chart version.
+    update.chartversion   Bump Semver chart version.
     reviewable            Run to see if everything fits.
 
 endef

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,7 +2,10 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 0.9.2
+version: 0.10.0
 appVersion: 0.25.3
 sources:
   - https://github.com/fluxcd-community/helm-charts
+annotations:
+  artifacthub.io/changes: |
+    - "[Added]: Add support for extra K8s manifests"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.25.3](https://img.shields.io/badge/AppVersion-0.25.3-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.25.3](https://img.shields.io/badge/AppVersion-0.25.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -20,6 +20,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.tag | string | `"v0.25.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy. In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
+| extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmcontroller.affinity | object | `{}` |  |
 | helmcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | helmcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |

--- a/charts/flux2/templates/extra-manifests.yaml
+++ b/charts/flux2/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.9.2
+        helm.sh/chart: flux2-0.10.0
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.9.2
+        helm.sh/chart: flux2-0.10.0
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.9.2
+        helm.sh/chart: flux2-0.10.0
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.25.3
-        helm.sh/chart: flux2-0.9.2
+        helm.sh/chart: flux2-0.10.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.9.2
+        helm.sh/chart: flux2-0.10.0
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.9.2
+        helm.sh/chart: flux2-0.10.0
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.25.3
         control-plane: controller
-        helm.sh/chart: flux2-0.9.2
+        helm.sh/chart: flux2-0.10.0
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/extra-manifests_test.yaml
+++ b/charts/flux2/tests/extra-manifests_test.yaml
@@ -1,0 +1,53 @@
+suite: test extra-manifests deployment
+templates:
+  - extra-manifests.yaml
+tests:
+  - it: should be empty if extra-manifests are not set
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should generate two manifests
+    set:
+      extraObjects:
+      - apiVersion: source.toolkit.fluxcd.io/v1beta1
+        kind: Bucket
+        metadata:
+          name: podinfo
+        spec:
+          interval: 1m
+      - apiVersion: source.toolkit.fluxcd.io/v1beta1
+        kind: Bucket
+        metadata:
+          name: podinfo2
+        spec:
+          interval: 2m
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Bucket
+      - isAPIVersion:
+          of: source.toolkit.fluxcd.io/v1beta1
+  - it: should have kind Bucket with testvalues
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+    set:
+      extraObjects:
+      - apiVersion: source.toolkit.fluxcd.io/v1beta1
+        kind: Bucket
+        metadata:
+          name: podinfo
+          namespace: default
+        spec:
+          provider: generic
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Bucket
+      - isAPIVersion:
+          of: source.toolkit.fluxcd.io/v1beta1
+      - equal:
+          path: spec.provider
+          value: generic

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -222,3 +222,29 @@ watchallnamespaces: true
 
 # -- contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers
 imagePullSecrets: []
+
+# -- Array of extra K8s manifests to deploy
+extraObjects: []
+# Example usage from https://fluxcd.io/docs/components/source/buckets/#static-authentication
+  # - apiVersion: source.toolkit.fluxcd.io/v1beta1
+  #   kind: Bucket
+  #   metadata:
+  #     name: podinfo
+  #     namespace: default
+  #   spec:
+  #     interval: 1m
+  #     provider: generic
+  #     bucketName: podinfo
+  #     endpoint: minio.minio.svc.cluster.local:9000
+  #     insecure: true
+  #     secretRef:
+  #       name: minio-credentials
+  # - apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: minio-credentials
+  #     namespace: default
+  #   type: Opaque
+  #   data:
+  #     accesskey: <BASE64>
+  #     secretkey: <BASE64>


### PR DESCRIPTION
Signed-off-by: Daniel Werdermann <daniel.werdermann@gmail.com>

<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Sometimes, accessory to the installation there may be manifest to be installed (for example a SecretProviderClass)

#### Which issue this PR fixes
  - fixes #71 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Run `make reviewable`
