### PR TITLE
Do not set resource limits

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -8,4 +8,4 @@ sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Update]: Update App Version to upstream 0.27.0"
+    - "[Update]: Remove default resource.limits from flux components"

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: 0.27.0
 sources:
   - https://github.com/fluxcd-community/helm-charts

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.0](https://img.shields.io/badge/AppVersion-0.27.0-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.0](https://img.shields.io/badge/AppVersion-0.27.0-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -29,8 +29,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmcontroller.image | string | `"ghcr.io/fluxcd/helm-controller"` |  |
 | helmcontroller.labels | object | `{}` |  |
 | helmcontroller.nodeSelector | object | `{}` |  |
-| helmcontroller.resources.limits.cpu | string | `"1000m"` |  |
-| helmcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| helmcontroller.resources.limits | object | `{}` |  |
 | helmcontroller.resources.requests.cpu | string | `"100m"` |  |
 | helmcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | helmcontroller.serviceaccount.annotations | object | `{}` |  |
@@ -46,8 +45,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageautomationcontroller.image | string | `"ghcr.io/fluxcd/image-automation-controller"` |  |
 | imageautomationcontroller.labels | object | `{}` |  |
 | imageautomationcontroller.nodeSelector | object | `{}` |  |
-| imageautomationcontroller.resources.limits.cpu | string | `"1000m"` |  |
-| imageautomationcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| imageautomationcontroller.resources.limits | object | `{}` |  |
 | imageautomationcontroller.resources.requests.cpu | string | `"100m"` |  |
 | imageautomationcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | imageautomationcontroller.serviceaccount.annotations | object | `{}` |  |
@@ -62,8 +60,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imagereflectorcontroller.image | string | `"ghcr.io/fluxcd/image-reflector-controller"` |  |
 | imagereflectorcontroller.labels | object | `{}` |  |
 | imagereflectorcontroller.nodeSelector | object | `{}` |  |
-| imagereflectorcontroller.resources.limits.cpu | string | `"1000m"` |  |
-| imagereflectorcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| imagereflectorcontroller.resources.limits | object | `{}` |  |
 | imagereflectorcontroller.resources.requests.cpu | string | `"100m"` |  |
 | imagereflectorcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | imagereflectorcontroller.serviceaccount.annotations | object | `{}` |  |
@@ -81,8 +78,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizecontroller.image | string | `"ghcr.io/fluxcd/kustomize-controller"` |  |
 | kustomizecontroller.labels | object | `{}` |  |
 | kustomizecontroller.nodeSelector | object | `{}` |  |
-| kustomizecontroller.resources.limits.cpu | string | `"1000m"` |  |
-| kustomizecontroller.resources.limits.memory | string | `"1Gi"` |  |
+| kustomizecontroller.resources.limits | object | `{}` |  |
 | kustomizecontroller.resources.requests.cpu | string | `"100m"` |  |
 | kustomizecontroller.resources.requests.memory | string | `"64Mi"` |  |
 | kustomizecontroller.secret.create | bool | `false` | Create a secret to use it with extraSecretMounts. Defaults to false. |
@@ -103,8 +99,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationcontroller.image | string | `"ghcr.io/fluxcd/notification-controller"` |  |
 | notificationcontroller.labels | object | `{}` |  |
 | notificationcontroller.nodeSelector | object | `{}` |  |
-| notificationcontroller.resources.limits.cpu | string | `"1000m"` |  |
-| notificationcontroller.resources.limits.memory | string | `"1Gi"` |  |
+| notificationcontroller.resources.limits | object | `{}` |  |
 | notificationcontroller.resources.requests.cpu | string | `"100m"` |  |
 | notificationcontroller.resources.requests.memory | string | `"64Mi"` |  |
 | notificationcontroller.service.labels | object | `{}` |  |
@@ -123,8 +118,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourcecontroller.image | string | `"ghcr.io/fluxcd/source-controller"` |  |
 | sourcecontroller.labels | object | `{}` |  |
 | sourcecontroller.nodeSelector | object | `{}` |  |
-| sourcecontroller.resources.limits.cpu | string | `"1000m"` |  |
-| sourcecontroller.resources.limits.memory | string | `"1Gi"` |  |
+| sourcecontroller.resources.limits | object | `{}` |  |
 | sourcecontroller.resources.requests.cpu | string | `"100m"` |  |
 | sourcecontroller.resources.requests.memory | string | `"64Mi"` |  |
 | sourcecontroller.service.labels | object | `{}` |  |

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.27.0
         control-plane: controller
-        helm.sh/chart: flux2-0.13.0
+        helm.sh/chart: flux2-0.14.0
       name: helm-controller
     spec:
       replicas: 1
@@ -56,9 +56,7 @@ should match snapshot of default values:
                 path: /readyz
                 port: healthz
             resources:
-              limits:
-                cpu: 1000m
-                memory: 1Gi
+              limits: {}
               requests:
                 cpu: 100m
                 memory: 64Mi

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.27.0
         control-plane: controller
-        helm.sh/chart: flux2-0.13.0
+        helm.sh/chart: flux2-0.14.0
       name: image-automation-controller
     spec:
       replicas: 1
@@ -54,9 +54,7 @@ should match snapshot of default values:
                 path: /readyz
                 port: healthz
             resources:
-              limits:
-                cpu: 1000m
-                memory: 1Gi
+              limits: {}
               requests:
                 cpu: 100m
                 memory: 64Mi

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.27.0
         control-plane: controller
-        helm.sh/chart: flux2-0.13.0
+        helm.sh/chart: flux2-0.14.0
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -54,9 +54,7 @@ should match snapshot of default values:
                 path: /readyz
                 port: healthz
             resources:
-              limits:
-                cpu: 1000m
-                memory: 1Gi
+              limits: {}
               requests:
                 cpu: 100m
                 memory: 64Mi

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.27.0
-        helm.sh/chart: flux2-0.13.0
+        helm.sh/chart: flux2-0.14.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.27.0
         control-plane: controller
-        helm.sh/chart: flux2-0.13.0
+        helm.sh/chart: flux2-0.14.0
       name: kustomize-controller
     spec:
       replicas: 1
@@ -54,9 +54,7 @@ should match snapshot of default values:
                 path: /readyz
                 port: healthz
             resources:
-              limits:
-                cpu: 1000m
-                memory: 1Gi
+              limits: {}
               requests:
                 cpu: 100m
                 memory: 64Mi

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.27.0
         control-plane: controller
-        helm.sh/chart: flux2-0.13.0
+        helm.sh/chart: flux2-0.14.0
       name: notification-controller
     spec:
       replicas: 1
@@ -60,9 +60,7 @@ should match snapshot of default values:
                 path: /readyz
                 port: healthz
             resources:
-              limits:
-                cpu: 1000m
-                memory: 1Gi
+              limits: {}
               requests:
                 cpu: 100m
                 memory: 64Mi

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.27.0
         control-plane: controller
-        helm.sh/chart: flux2-0.13.0
+        helm.sh/chart: flux2-0.14.0
       name: source-controller
     spec:
       replicas: 1
@@ -62,9 +62,7 @@ should match snapshot of default values:
                 path: /
                 port: http
             resources:
-              limits:
-                cpu: 1000m
-                memory: 1Gi
+              limits: {}
               requests:
                 cpu: 100m
                 memory: 64Mi

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -37,9 +37,9 @@ helmcontroller:
   image: ghcr.io/fluxcd/helm-controller
   tag: v0.17.0
   resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+    limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
     requests:
       cpu: 100m
       memory: 64Mi
@@ -81,9 +81,9 @@ imageautomationcontroller:
   image: ghcr.io/fluxcd/image-automation-controller
   tag: v0.20.0
   resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+    limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
     requests:
       cpu: 100m
       memory: 64Mi
@@ -105,9 +105,9 @@ imagereflectorcontroller:
   image: ghcr.io/fluxcd/image-reflector-controller
   tag: v0.16.0
   resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+    limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
     requests:
       cpu: 100m
       memory: 64Mi
@@ -129,9 +129,9 @@ kustomizecontroller:
   image: ghcr.io/fluxcd/kustomize-controller
   tag: v0.21.0
   resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+    limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
     requests:
       cpu: 100m
       memory: 64Mi
@@ -173,9 +173,9 @@ notificationcontroller:
   image: ghcr.io/fluxcd/notification-controller
   tag: v0.22.0
   resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+    limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
     requests:
       cpu: 100m
       memory: 64Mi
@@ -199,9 +199,9 @@ sourcecontroller:
   image: ghcr.io/fluxcd/source-controller
   tag: v0.21.2
   resources:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
+    limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
     requests:
       cpu: 100m
       memory: 64Mi


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR removes default values for resource.limits. Helm recommends not to specify default resources and to leave this as a conscious choice for the user.
We currently have two issues with default resources:
1. Using CPU limits leads to unnecessary throttling - https://github.com/kubernetes/kubernetes/issues/67577
2. We can not unset the cpu limit key in a sub-chart due to a bug in Helm - https://github.com/helm/helm/issues/9027

Most community helm charts do not set resources but provide guidance with some commented values instead. 

Thanks!

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
