### PR TITLE
feat(flux2-sync): update git repository resource to v1beta2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Once changes have been merged, the release job will automatically run to package
 
 * Make your changes
 * run: ```helm install --dry-run charts/flux2/ --generate-name```
-* run: ```helm unittest --helm3 --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2/```
+* run: ```helm unittest --helm3 --file 'tests/*.yaml' charts/flux2/```
     * add ```-u``` if you need to update the compare snapshot in \_\_snapshots\_\_
 * bump chart version if necessary
 * run: ```make helmdocs```

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,9 +1,18 @@
 apiVersion: v2
 name: flux2-sync
-version: 0.3.6
+version: 0.3.7
 
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 
 type: application
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: update apiVersion of GitRepository resource to v1beta2
+      links:
+        - name: GitHub Issue
+          url: https://github.com/fluxcd-community/helm-charts/issues/89
+        - name: GitHub PR
+          url: https://github.com/fluxcd-community/helm-charts/pull/90

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.7](https://img.shields.io/badge/Version-0.3.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 

--- a/charts/flux2-sync/templates/gitrepository.yaml
+++ b/charts/flux2-sync/templates/gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   labels:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-0.3.6
+        helm.sh/chart: flux2-sync-0.3.7
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.2](https://img.shields.io/badge/AppVersion-0.29.2-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.3](https://img.shields.io/badge/AppVersion-0.29.3-informational?style=flat-square)
 
 A Helm chart for flux2
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the `apiVersion` for the `GitRepository` resource in the `flux2-sync` chart to `v1beta2`. This api version was released in [source-controller v0.22.0](https://github.com/fluxcd/source-controller/blob/main/CHANGELOG.md#0220) as of 17-MAR-2022.

#### Which issue this PR fixes

Fixes: #89

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
