### PR TITLE
Fix typo in notificationcontroller services annotations

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 0.18.1
+version: 0.18.2
 appVersion: 0.29.3
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Allow custom labels and annotations for all services"
+    - "[Fixed]: Typo in notificationcontroller services annotations"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 0.18.1](https://img.shields.io/badge/Version-0.18.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.3](https://img.shields.io/badge/AppVersion-0.29.3-informational?style=flat-square)
+![Version: 0.18.2](https://img.shields.io/badge/Version-0.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.29.3](https://img.shields.io/badge/AppVersion-0.29.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -102,13 +102,13 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationcontroller.resources.limits | object | `{}` |  |
 | notificationcontroller.resources.requests.cpu | string | `"100m"` |  |
 | notificationcontroller.resources.requests.memory | string | `"64Mi"` |  |
-| notificationcontroller.service.annotation | object | `{}` |  |
+| notificationcontroller.service.annotations | object | `{}` |  |
 | notificationcontroller.service.labels | object | `{}` |  |
 | notificationcontroller.serviceaccount.annotations | object | `{}` |  |
 | notificationcontroller.serviceaccount.create | bool | `true` |  |
 | notificationcontroller.tag | string | `"v0.23.4"` |  |
 | notificationcontroller.tolerations | list | `[]` |  |
-| notificationcontroller.webhookReceiver.service.annotation | object | `{}` |  |
+| notificationcontroller.webhookReceiver.service.annotations | object | `{}` |  |
 | notificationcontroller.webhookReceiver.service.labels | object | `{}` |  |
 | policies.create | bool | `true` |  |
 | prometheus.podMonitor.create | bool | `false` |  |

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.29.3
         control-plane: controller
-        helm.sh/chart: flux2-0.18.1
+        helm.sh/chart: flux2-0.18.2
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.29.3
         control-plane: controller
-        helm.sh/chart: flux2-0.18.1
+        helm.sh/chart: flux2-0.18.2
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.29.3
         control-plane: controller
-        helm.sh/chart: flux2-0.18.1
+        helm.sh/chart: flux2-0.18.2
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.29.3
-        helm.sh/chart: flux2-0.18.1
+        helm.sh/chart: flux2-0.18.2
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.29.3
         control-plane: controller
-        helm.sh/chart: flux2-0.18.1
+        helm.sh/chart: flux2-0.18.2
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.29.3
         control-plane: controller
-        helm.sh/chart: flux2-0.18.1
+        helm.sh/chart: flux2-0.18.2
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.29.3
         control-plane: controller
-        helm.sh/chart: flux2-0.18.1
+        helm.sh/chart: flux2-0.18.2
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -190,11 +190,11 @@ notificationcontroller:
     annotations: {}
   service:
     labels: {}
-    annotation: {}
+    annotations: {}
   webhookReceiver:
     service:
       labels: {}
-      annotation: {}
+      annotations: {}
   nodeSelector: {}
   affinity: {}
   tolerations: []


### PR DESCRIPTION
Signed-off-by: Marco Davalos <marco.davalosmantilla@ravelin.com>

#### What this PR does / why we need it:
Fix typo in notificationcontroller services annotations.

#### Checklist
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
