### PR TITLE
Add chart for creating HelmRepository

### DIFF
--- a/.github/workflows/e2e-sync.yaml
+++ b/.github/workflows/e2e-sync.yaml
@@ -40,6 +40,8 @@ jobs:
           --create-namespace \
           --set gitRepository.spec.url=https://github.com/stefanprodan/podinfo.git \
           --set gitRepository.spec.ref.branch=master \
+          --set helmRepository.spec.url=https://helm.github.io/examples
+          --set helmRepository.spec.secretRef.name=helmSecret
           --set kustomization.spec.path=kustomize \
           --set kustomization.spec.targetNamespace=podinfo \
           --set kustomization.spec.wait=true \

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: flux2-sync
-version: 0.3.8
+version: 0.3.9
 
 description: A Helm chart for flux2 GitRepository to sync with
 sources:

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -14,34 +14,40 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| gitRepository.spec.gitImplementation | string | `""` | (Optional) Determines which git client library to use. Defaults to go-git, valid values are (‘go-git’, ‘libgit2’). |
-| gitRepository.spec.ignore | string | `""` | (Optional) Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are. |
-| gitRepository.spec.include | list | `[]` | (Optional) Extra git repositories to map into the repository |
+| gitRepository.spec.gitImplementation | Optional | `""` | Determines which git client library to use. Defaults to go-git, valid values are (‘go-git’, ‘libgit2’). |
+| gitRepository.spec.ignore | Optional | `""` | Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are. |
+| gitRepository.spec.include | Optional | `[]` | Extra git repositories to map into the repository |
 | gitRepository.spec.interval | string | `"5m"` | The interval at which to check for repository updates. |
-| gitRepository.spec.recurseSubmodules | bool | `false` | (Optional) When enabled, after the clone is created, initializes all submodules within, using their default settings. This option is available only when using the ‘go-git’ GitImplementation. |
-| gitRepository.spec.ref | object | `{"branch":"master"}` | (Optional) The Git reference to checkout and monitor for changes, defaults to master branch. |
-| gitRepository.spec.secretRef | object | `{}` | (Optional) The secret name containing the Git credentials. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields. If a secret.create is set, it will point to that one. |
-| gitRepository.spec.suspend | string | `""` | (Optional) This flag tells the controller to suspend the reconciliation of this source. |
-| gitRepository.spec.timeout | string | `""` | (Optional) The timeout for remote Git operations like cloning, defaults to 20s. |
-| gitRepository.spec.url | string | `""` | The repository URL, can be an HTTP/S or SSH address. |
-| gitRepository.spec.verify | object | `{}` | (Optional) Verify OpenPGP signature for the Git commit HEAD points to. |
-| kustomization.spec.decryption | object | `{}` | (Optional) Decrypt Kubernetes secrets before applying them on the cluster. |
-| kustomization.spec.dependsOn | list | `[]` | (Optional) DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to Kustomization resources that must be ready before this Kustomization can be reconciled. |
-| kustomization.spec.force | bool | `false` | (Optional) Force instructs the controller to recreate resources when patching fails due to an immutable field change. Defaults to false. |
-| kustomization.spec.healthChecks | list | `[]` | (Optional) A list of resources to be included in the health assessment. |
-| kustomization.spec.images | list | `[]` | (Optional) Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify. |
+| gitRepository.spec.recurseSubmodules | Optional | `false` | When enabled, after the clone is created, initializes all submodules within, using their default settings. This option is available only when using the ‘go-git’ GitImplementation. |
+| gitRepository.spec.ref | Optional | `{"branch":"master"}` | The Git reference to checkout and monitor for changes, defaults to master branch. |
+| gitRepository.spec.secretRef | Optional | `{}` | The secret name containing the Git credentials. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields. If a secret.create is set, it will point to that one. |
+| gitRepository.spec.suspend | Optional | `""` | This flag tells the controller to suspend the reconciliation of this source. |
+| gitRepository.spec.timeout | Optional | `""` | The timeout for remote Git operations like cloning, defaults to 20s. |
+| gitRepository.spec.url | string | `""` | The Git repository URL, can be an HTTP/S or SSH address. |
+| gitRepository.spec.verify | Optional | `{}` | Verify OpenPGP signature for the Git commit HEAD points to. |
+| helmRepository.spec.interval | string | `"5m"` | The interval at which the Helm repository index is consulted at. |
+| helmRepository.spec.passCredentials | Optional | `false` | Whether credentials from the Secret reference is allowed to be passed on to a host that does not match the host as defined in URL. Enable this with caution, as credentials can get stolen in a man-in-the-middle attack. |
+| helmRepository.spec.secretRef | object | `{}` | The secret name containing the Helm credentials. For basic access authentication the secret must contain username and password fields. For TLS authentication the secret must contain certFile, keyFile and/or caFile fields. |
+| helmRepository.spec.suspend | Optional | `""` | This flag tells the controller to suspend the reconciliation of this source. |
+| helmRepository.spec.timeout | Optional | `""` | The timeout for fetch operations, defaults to 60s. |
+| helmRepository.spec.url | string | `""` | The HTTP/S address of the Helm repository. |
+| kustomization.spec.decryption | Optional | `{}` | Decrypt Kubernetes secrets before applying them on the cluster. |
+| kustomization.spec.dependsOn | Optional | `[]` | DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to Kustomization resources that must be ready before this Kustomization can be reconciled. |
+| kustomization.spec.force | Optional | `false` | Force instructs the controller to recreate resources when patching fails due to an immutable field change. Defaults to false. |
+| kustomization.spec.healthChecks | Optional | `[]` | A list of resources to be included in the health assessment. |
+| kustomization.spec.images | Optional | `[]` | Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify. |
 | kustomization.spec.interval | string | `"5m"` | The interval at which to reconcile the Kustomization. |
-| kustomization.spec.kubeConfig | object | `{}` | (Optional) The KubeConfig for reconciling the Kustomization on a remote cluster. When specified, KubeConfig takes precedence over ServiceAccountName. |
-| kustomization.spec.patches | list | `[]` | (Optional) Strategic merge and JSON patches, defined as inline YAML objects, capable of targeting objects based on kind, label and annotation selectors. |
-| kustomization.spec.path | string | `""` | (Optional) Path to the directory containing the kustomization.yaml file, or the set of plain YAMLs a kustomization.yaml should be generated for. Defaults to ‘None’, which translates to the root path of the SourceRef. |
-| kustomization.spec.postBuild | object | `{}` | (Optional) PostBuild describes which actions to perform on the YAML manifest generated by building the kustomize overlay. |
+| kustomization.spec.kubeConfig | Optional | `{}` | The KubeConfig for reconciling the Kustomization on a remote cluster. When specified, KubeConfig takes precedence over ServiceAccountName. |
+| kustomization.spec.patches | Optional | `[]` | Strategic merge and JSON patches, defined as inline YAML objects, capable of targeting objects based on kind, label and annotation selectors. |
+| kustomization.spec.path | Optional | `""` | Path to the directory containing the kustomization.yaml file, or the set of plain YAMLs a kustomization.yaml should be generated for. Defaults to ‘None’, which translates to the root path of the SourceRef. |
+| kustomization.spec.postBuild | Optional | `{}` | PostBuild describes which actions to perform on the YAML manifest generated by building the kustomize overlay. |
 | kustomization.spec.prune | bool | `true` | Prune enables garbage collection. Defaults to true. |
-| kustomization.spec.retryInterval | string | `""` | (Optional) The interval at which to retry a previously failed reconciliation. When not specified, the controller uses the KustomizationSpec.Interval value to retry failures. |
-| kustomization.spec.serviceAccountName | string | `""` | (Optional) The name of the Kubernetes service account to impersonate when reconciling this Kustomization. |
-| kustomization.spec.suspend | string | `""` | (Optional) This flag tells the controller to suspend subsequent kustomize executions, it does not apply to already started executions. Defaults to false. |
-| kustomization.spec.targetNamespace | string | `""` | (Optional) TargetNamespace sets or overrides the namespace in the kustomization.yaml file. |
-| kustomization.spec.timeout | string | `""` | (Optional) Timeout for validation, apply and health checking operations. Defaults to ‘Interval’ duration |
-| kustomization.spec.wait | bool | `false` | (Optional) Wait instructs the controller to check the health of all the reconciled resources. When enabled, the HealthChecks are ignored. Defaults to false. |
-| kustomizationlist | object | `{}` | (Optional) If you want multiple subdirectories which depend on each other in the same repo. Their name is derived from their path. |
+| kustomization.spec.retryInterval | Optional | `""` | The interval at which to retry a previously failed reconciliation. When not specified, the controller uses the KustomizationSpec.Interval value to retry failures. |
+| kustomization.spec.serviceAccountName | Optional | `""` | The name of the Kubernetes service account to impersonate when reconciling this Kustomization. |
+| kustomization.spec.suspend | Optional | `""` | This flag tells the controller to suspend subsequent kustomize executions, it does not apply to already started executions. Defaults to false. |
+| kustomization.spec.targetNamespace | Optional | `""` | TargetNamespace sets or overrides the namespace in the kustomization.yaml file. |
+| kustomization.spec.timeout | Optional | `""` | Timeout for validation, apply and health checking operations. Defaults to ‘Interval’ duration |
+| kustomization.spec.wait | Optional | `false` | Wait instructs the controller to check the health of all the reconciled resources. When enabled, the HealthChecks are ignored. Defaults to false. |
+| kustomizationlist | Optional | `{}` | If you want multiple subdirectories which depend on each other in the same repo. Their name is derived from their path. |
 | secret.create | bool | `false` | Create a secret for the git repository. Defaults to false. |
 | secret.data | object | `{}` | Data of the secret. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields. Values will be encoded to base64 by the helm chart. |

--- a/charts/flux2-sync/templates/helmrepository.yaml
+++ b/charts/flux2-sync/templates/helmrepository.yaml
@@ -1,0 +1,25 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  url: {{ .Values.helmRepository.spec.url }}
+  secretRef: {{ toYaml .Values.helmRepository.spec.secretRef | nindent 4 }}
+  {{- if .Values.helmRepository.spec.interval }}
+  interval: {{ .Values.helmRepository.spec.interval }}
+  {{- end }}
+  {{- if .Values.helmRepository.spec.timeout }}
+  timeout: {{ .Values.helmRepository.spec.timeout }}
+  {{- end }}
+  {{- if .Values.helmRepository.spec.passCredentials }}
+  passCredentials: {{ .Values.helmRepository.spec.passCredentials }}
+  {{- end }}
+  {{- if .Values.helmRepository.spec.suspend }}
+  suspend: {{ .Values.helmRepository.spec.suspend }}
+  {{- end }}

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-0.3.8
+        helm.sh/chart: flux2-sync-0.3.9
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -10,7 +10,7 @@ secret:
 
 gitRepository:
   spec:
-    # -- The repository URL, can be an HTTP/S or SSH address.
+    # -- The Git repository URL, can be an HTTP/S or SSH address.
     url: ""
 
     # -- (Optional) The secret name containing the Git credentials.
@@ -47,6 +47,28 @@ gitRepository:
     # -- (Optional) Extra git repositories to map into the repository
     include: []
 
+helmRepository:
+  spec:
+    # -- The HTTP/S address of the Helm repository.
+    url: ""
+
+    # -- The secret name containing the Helm credentials.
+    # For basic access authentication the secret must contain username and password fields.
+    # For TLS authentication the secret must contain certFile, keyFile and/or caFile fields.
+    secretRef: {}
+
+    # -- The interval at which the Helm repository index is consulted at.
+    interval: 5m
+
+    # -- (Optional) Whether credentials from the Secret reference is allowed to be passed on to a host that does not match the host as defined in URL.
+    # Enable this with caution, as credentials can get stolen in a man-in-the-middle attack.
+    passCredentials: false
+
+    # -- (Optional) The timeout for fetch operations, defaults to 60s.
+    timeout: ""
+
+    # -- (Optional) This flag tells the controller to suspend the reconciliation of this source.
+    suspend: ""
 
 kustomization:
   spec:

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -19,7 +19,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.nodeSelector | object | `{}` |  |
 | cli.tag | string | `"v0.30.2"` |  |
 | cli.tolerations | list | `[]` |  |
-| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy. In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
+| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy.  In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmcontroller.affinity | object | `{}` |  |
 | helmcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the option for deploying a HelmRepository k8s object to the flux2-sync chart.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [ ] Run `make reviewable`
