### PR TITLE
Adds Git SSH Key Generation

### DIFF
--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: flux2-sync
-version: 0.3.8
+version: 0.4.0
 
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
@@ -16,3 +16,10 @@ annotations:
           url: https://github.com/fluxcd-community/helm-charts/issues/89
         - name: GitHub PR
           url: https://github.com/fluxcd-community/helm-charts/pull/90
+    - kind: added
+      description: adds Git SSH Key generation
+      links:
+        - name: GitHub Issue
+          url: https://github.com/fluxcd-community/helm-charts/issues/101
+        - name: GitHub PR
+          url: https://github.com/fluxcd-community/helm-charts/pull/102

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -45,3 +45,5 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizationlist | object | `{}` | (Optional) If you want multiple subdirectories which depend on each other in the same repo. Their name is derived from their path. |
 | secret.create | bool | `false` | Create a secret for the git repository. Defaults to false. |
 | secret.data | object | `{}` | Data of the secret. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields. Values will be encoded to base64 by the helm chart. |
+| secret.generate.sshKeyAlgorithm | string | `ecdsa` | If `secret.create` is set to `true` and `secret.data` is empty, the chart will generate Git SSH keys using the `sshKeyAlgorithm` specified. |
+| secret.generate.sshEcdsaCurve | string | `p521` | If `secret.create` is set to `true` and `secret.data` is empty, the chart will generate Git SSH keys using the `sshEcdsaCurve` specified. |

--- a/charts/flux2-sync/templates/_helpers.tpl
+++ b/charts/flux2-sync/templates/_helpers.tpl
@@ -1,3 +1,11 @@
 {{- define "pathToKustomizationName" -}}
 {{ print .releasename "-" ( regexReplaceAll "\\W+" (clean .pathtoconvert ) "-" ) }}
 {{- end -}}
+
+{{- define "template.image" -}}
+{{- if eq (substr 0 7 .tag) "sha256:" -}}
+{{- printf "%s@%s" .image .tag -}}
+{{- else -}}
+{{- printf "%s:%s" .image .tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/flux2-sync/templates/generate-git-secret-service-account.yaml
+++ b/charts/flux2-sync/templates/generate-git-secret-service-account.yaml
@@ -1,0 +1,16 @@
+{{- if and (.Values.secret.create) (not .Values.secret.data) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: "{{ .Release.Name }}-generate-git-secret"
+  annotations: 
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- end }}

--- a/charts/flux2-sync/templates/generate-git-secret.yaml
+++ b/charts/flux2-sync/templates/generate-git-secret.yaml
@@ -1,0 +1,49 @@
+{{- if and (.Values.secret.create) (not .Values.secret.data) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-generate-git-secret"
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+        app.kubernetes.io/part-of: flux
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: "{{ .Release.Name }}-generate-git-secret"
+      containers:
+      - name: flux-cli
+        image: {{ template "template.image" .Values.cli }}
+        command: 
+          ["/usr/local/bin/flux", "create",  "secret", "git", {{ .Release.Name }},
+          "--url={{ .Values.gitRepository.spec.url }}",
+          "--ssh-key-algorithm={{ .Values.secret.generate.sshKeyAlgorithm }}",
+          "--ssh-ecdsa-curve={{ .Values.secret.generate.sshEcdsaCurve }}",
+          "--namespace={{ .Release.Namespace }}",
+          ]
+      {{- with .Values.cli.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cli.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cli.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/flux2-sync/templates/role.yaml
+++ b/charts/flux2-sync/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.secret.create) (not .Values.secret.data) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: secret-generator
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-7"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["*"]
+{{- end }}

--- a/charts/flux2-sync/templates/rolebinding.yaml
+++ b/charts/flux2-sync/templates/rolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if and (.Values.secret.create) (not .Values.secret.data) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: write-secrets
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+      app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+      app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+      app.kubernetes.io/part-of: flux
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-6"
+subjects:
+- kind: ServiceAccount
+  name: "{{ .Release.Name }}-generate-git-secret"
+  namespace: {{ .Release.Namespace | quote }}
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: secret-generator
+  apiGroup: ""
+{{- end }}

--- a/charts/flux2-sync/templates/secret.yaml
+++ b/charts/flux2-sync/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.secret.create }}
+{{- if and .Values.secret.create .Values.secret.data }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-0.3.8
+        helm.sh/chart: flux2-sync-0.4.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -8,6 +8,20 @@ secret:
   # Values will be encoded to base64 by the helm chart.
   data: {}
 
+  # -- Algorithm of keys to generate.
+  # If `data` object above is empty, and `create` is set to true. The Chart will generate the
+  # Git SSH key secret automatically based on the key algorithms that are set below.
+  generate:
+    sshKeyAlgorithm: ecdsa
+    sshEcdsaCurve: p521
+
+cli:
+  image: ghcr.io/fluxcd/flux-cli
+  tag: v0.30.2
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 gitRepository:
   spec:
     # -- The repository URL, can be an HTTP/S or SSH address.


### PR DESCRIPTION
Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>

#### What this PR does / why we need it:
Adds automatic Git SSH key generation if configured by user of Chart.


#### Which issue this PR fixes
https://github.com/fluxcd-community/helm-charts/issues/101

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [ ] Run `make reviewable`
