### PR TITLE
feat: Add multitenancy privileged mode

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: 0.33.0
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Update]: Filter out non-running pods in Prometheus"
+    - "[Feature]: Add support for running flux service accounts without cluster-admin privileges"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -99,6 +99,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | loglevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
 | multitenancy.enabled | bool | `false` | Implement the patches for Multi-tenancy lockdown. See https://fluxcd.io/docs/installation/#multi-tenancy-lockdown |
+| multitenancy.privileged | bool | `true` | Both kustomize-controller and helm-controller service accounts run privileged  with cluster-admin ClusterRoleBinding. Disable if you want to run them with a  minimum set of permissions. |
 | notificationcontroller.affinity | object | `{}` |  |
 | notificationcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
 | notificationcontroller.annotations."prometheus.io/scrape" | string | `"true"` |  |

--- a/charts/flux2/templates/cluster-reconciler-impersonator-clusterrole.yaml
+++ b/charts/flux2/templates/cluster-reconciler-impersonator-clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.multitenancy.enabled (not .Values.multitenancy.privileged) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-reconciler-impersonator
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["impersonate"]
+{{- end }}

--- a/charts/flux2/templates/cluster-reconciler-impersonator-clusterrolebinding.yaml
+++ b/charts/flux2/templates/cluster-reconciler-impersonator-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (or (not .Values.multitenancy.enabled) .Values.multitenancy.privileged) }}
+{{- if and .Values.rbac.create .Values.multitenancy.enabled (not .Values.multitenancy.privileged) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -8,11 +8,11 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
     app.kubernetes.io/part-of: flux
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  name: cluster-reconciler
+  name: cluster-reconciler-impersonator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: cluster-reconciler-impersonator
 subjects:
 - kind: ServiceAccount
   name: kustomize-controller

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.3.0
+        helm.sh/chart: flux2-1.4.0
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.3.0
+        helm.sh/chart: flux2-1.4.0
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.3.0
+        helm.sh/chart: flux2-1.4.0
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
-        helm.sh/chart: flux2-1.3.0
+        helm.sh/chart: flux2-1.4.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.3.0
+        helm.sh/chart: flux2-1.4.0
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.3.0
+        helm.sh/chart: flux2-1.4.0
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.3.0
+        helm.sh/chart: flux2-1.4.0
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
+++ b/charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
@@ -1,0 +1,31 @@
+suite: test cluster reconciler
+templates:
+  - cluster-reconciler-clusterrolebinding.yaml
+tests:
+  - it: should be empty if rbac is disabled
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be empty if multitenancy-lockdown is enabled with privileged mode disabled
+    set:
+      multitenancy.enabled: true
+      multitenancy.privileged: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be created if multitenancy-lockdown is disabled with privileged mode enabled
+    set:
+      multitenancy.enabled: false
+      multitenancy.privileged: true
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: should be created if multitenancy-lockdown is enabled with privileged mode enabled
+    set:
+      multitenancy.enabled: false
+      multitenancy.privileged: false
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/flux2/tests/cluster-reconciler-impersonator-clusterrole_test.yaml
+++ b/charts/flux2/tests/cluster-reconciler-impersonator-clusterrole_test.yaml
@@ -1,0 +1,31 @@
+suite: test cluster reconciler impersonator clusterrole
+templates:
+  - cluster-reconciler-impersonator-clusterrole.yaml
+tests:
+  - it: should be empty if rbac is disabled
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be empty if multitenancy-lockdown is disabled with privileged mode enabled
+    set:
+      multitenancy.enabled: false
+      multitenancy.privileged: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be empty if multitenancy-lockdown is enabled with privileged mode enabled
+    set:
+      multitenancy.enabled: false
+      multitenancy.privileged: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be empty if multitenancy-lockdown is enabled with privileged mode disabled
+    set:
+      multitenancy.enabled: true
+      multitenancy.privileged: false
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/flux2/tests/cluster-reconciler-impersonator-clusterrolebinding.yaml
+++ b/charts/flux2/tests/cluster-reconciler-impersonator-clusterrolebinding.yaml
@@ -1,0 +1,31 @@
+suite: test cluster reconciler impersonator clusterrole
+templates:
+  - cluster-reconciler-impersonator-clusterrolebinding.yaml
+tests:
+  - it: should be empty if rbac is disabled
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be empty if multitenancy-lockdown is disabled with privileged mode enabled
+    set:
+      multitenancy.enabled: false
+      multitenancy.privileged: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be empty if multitenancy-lockdown is enabled with privileged mode enabled
+    set:
+      multitenancy.enabled: false
+      multitenancy.privileged: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be empty if multitenancy-lockdown is enabled with privileged mode disabled
+    set:
+      multitenancy.enabled: true
+      multitenancy.privileged: false
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -11,6 +11,10 @@ multitenancy:
   # Tenants have to specify a service account in their Flux resources to be able
   # to deploy workloads in their namespaces as the default account has no permissions.
   defaultServiceAccount: "default"
+  # -- Both kustomize-controller and helm-controller service accounts run privileged
+  # with cluster-admin ClusterRoleBinding. Disable if you want to run them with a
+  # minimum set of permissions.
+  privileged: true
 
 # -- Maybe you need to use full domain name here, if you deploy flux
 # in environments that use http proxy.


### PR DESCRIPTION
#### What this PR does / why we need it:

This change aims to add the possibility of both kustomize-controller and helm-controller service accounts to not become cluster-admins.

In Kubernetes Clusters with a very agressive security posture we want to avoid to run service accounts with cluster admin privileges.

If the privileged mode is turned off we will only add service account impersonation capabilities to the kustomize-controller and helm-controller service accounts so they can only impersonate other service accounts that are usually set on the Kustomizations / Helm Releases.

#### Which Issue does it fix:

#111 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
