### PR TITLE
feat: add imagePullPolicy to all controllers

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: 0.31.3
 sources:
   - https://github.com/fluxcd-community/helm-charts

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 1.2.1
+version: 1.3.1
 appVersion: 0.33.0
 sources:
   - https://github.com/fluxcd-community/helm-charts

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.31.3](https://img.shields.io/badge/AppVersion-0.31.3-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.31.3](https://img.shields.io/badge/AppVersion-0.31.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.nodeSelector | object | `{}` |  |
 | cli.tag | string | `"v0.31.3"` |  |
 | cli.tolerations | list | `[]` |  |
-| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy. In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
+| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy.  In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmcontroller.affinity | object | `{}` |  |
 | helmcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -27,6 +27,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmcontroller.container.additionalargs | list | `[]` |  |
 | helmcontroller.create | bool | `true` |  |
 | helmcontroller.image | string | `"ghcr.io/fluxcd/helm-controller"` |  |
+| helmcontroller.imagePullPolicy | object | `{}` |  |
 | helmcontroller.labels | object | `{}` |  |
 | helmcontroller.nodeSelector | object | `{}` |  |
 | helmcontroller.resources.limits | object | `{}` |  |
@@ -43,6 +44,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageautomationcontroller.container.additionalargs | list | `[]` |  |
 | imageautomationcontroller.create | bool | `true` |  |
 | imageautomationcontroller.image | string | `"ghcr.io/fluxcd/image-automation-controller"` |  |
+| imageautomationcontroller.imagePullPolicy | object | `{}` |  |
 | imageautomationcontroller.labels | object | `{}` |  |
 | imageautomationcontroller.nodeSelector | object | `{}` |  |
 | imageautomationcontroller.resources.limits | object | `{}` |  |
@@ -58,6 +60,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imagereflectorcontroller.container.additionalargs | list | `[]` |  |
 | imagereflectorcontroller.create | bool | `true` |  |
 | imagereflectorcontroller.image | string | `"ghcr.io/fluxcd/image-reflector-controller"` |  |
+| imagereflectorcontroller.imagePullPolicy | object | `{}` |  |
 | imagereflectorcontroller.labels | object | `{}` |  |
 | imagereflectorcontroller.nodeSelector | object | `{}` |  |
 | imagereflectorcontroller.resources.limits | object | `{}` |  |
@@ -76,6 +79,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizecontroller.envFrom | object | `{"map":{"name":""},"secret":{"name":""}}` | Defines envFrom using a configmap and/or secret. |
 | kustomizecontroller.extraSecretMounts | list | `[]` | Defines additional mounts with secrets. Secrets must be manually created in the namespace or with kustomizecontroller.secret |
 | kustomizecontroller.image | string | `"ghcr.io/fluxcd/kustomize-controller"` |  |
+| kustomizecontroller.imagePullPolicy | object | `{}` |  |
 | kustomizecontroller.labels | object | `{}` |  |
 | kustomizecontroller.nodeSelector | object | `{}` |  |
 | kustomizecontroller.resources.limits | object | `{}` |  |
@@ -97,6 +101,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationcontroller.container.additionalargs | list | `[]` |  |
 | notificationcontroller.create | bool | `true` |  |
 | notificationcontroller.image | string | `"ghcr.io/fluxcd/notification-controller"` |  |
+| notificationcontroller.imagePullPolicy | object | `{}` |  |
 | notificationcontroller.labels | object | `{}` |  |
 | notificationcontroller.nodeSelector | object | `{}` |  |
 | notificationcontroller.resources.limits | object | `{}` |  |
@@ -120,6 +125,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourcecontroller.create | bool | `true` |  |
 | sourcecontroller.extraEnv | list | `[]` |  |
 | sourcecontroller.image | string | `"ghcr.io/fluxcd/source-controller"` |  |
+| sourcecontroller.imagePullPolicy | object | `{}` |  |
 | sourcecontroller.labels | object | `{}` |  |
 | sourcecontroller.nodeSelector | object | `{}` |  |
 | sourcecontroller.resources.limits | object | `{}` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -52,7 +52,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: {{ template "template.image" .Values.helmcontroller }}
+        {{- if .Values.helmcontroller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.helmcontroller.imagePullPolicy }}
+        {{- else }}
         imagePullPolicy: IfNotPresent
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -52,7 +52,7 @@ spec:
               fieldPath: metadata.namespace
         image: {{ template "template.image" .Values.imageautomationcontroller }}
         {{- if .Values.imageautomationcontroller.imagePullPolicy }}
-        imagePullPolicy: { { .Values.imageautomationcontroller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.imageautomationcontroller.imagePullPolicy }}
         {{- else }}
         imagePullPolicy: IfNotPresent
         {{- end }}

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -51,7 +51,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: {{ template "template.image" .Values.imageautomationcontroller }}
+        {{- if .Values.imageautomationcontroller.imagePullPolicy }}
+        imagePullPolicy: { { .Values.imageautomationcontroller.imagePullPolicy }}
+        {{- else }}
         imagePullPolicy: IfNotPresent
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -51,7 +51,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: {{ template "template.image" .Values.imagereflectorcontroller }}
+        {{- if .Values.imagereflectorcontroller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.imagereflectorcontroller.imagePullPolicy }}
+        {{- else }}
         imagePullPolicy: IfNotPresent
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -63,7 +63,11 @@ spec:
           {{- end }}
         {{- end }}
         image: {{ template "template.image" .Values.kustomizecontroller }}
+        {{- if .Values.kustomizecontroller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.kustomizecontroller.imagePullPolicy }}
+        {{- else }}
         imagePullPolicy: IfNotPresent
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -50,7 +50,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: {{ template "template.image" .Values.notificationcontroller }}
+        {{- if .Values.notificationcontroller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.notificationcontroller.imagePullPolicy }}
+        {{- else }}
         imagePullPolicy: IfNotPresent
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -55,7 +55,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         image: {{ template "template.image" .Values.sourcecontroller }}
+        {{- if .Values.sourcecontroller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.sourcecontroller.imagePullPolicy }}
+        {{- else }}
         imagePullPolicy: IfNotPresent
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.3.1
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.3.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.3.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.3.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.3.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.3.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.3.1
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/helm-controller_test.yaml
+++ b/charts/flux2/tests/helm-controller_test.yaml
@@ -62,3 +62,15 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             --default-service-account=test1
+  - it: should set imagePullPolicy to Always
+    set:
+      helmcontroller.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should imagePullPolicy to be default value IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/charts/flux2/tests/image-automation-controller_test.yaml
+++ b/charts/flux2/tests/image-automation-controller_test.yaml
@@ -49,3 +49,15 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             --no-cross-namespace-refs=true
+  - it: should set imagePullPolicy to Always
+    set:
+      imageautomationcontroller.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should imagePullPolicy to be default value IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/charts/flux2/tests/image-reflector-controller_test.yaml
+++ b/charts/flux2/tests/image-reflector-controller_test.yaml
@@ -50,3 +50,15 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             --no-cross-namespace-refs=true
+  - it: should set imagePullPolicy to Always
+    set:
+      imagereflectorcontroller.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should imagePullPolicy to be default value IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/charts/flux2/tests/kustomize-controller_test.yaml
+++ b/charts/flux2/tests/kustomize-controller_test.yaml
@@ -54,3 +54,15 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             --default-service-account=test1
+  - it: should set imagePullPolicy to Always
+    set:
+      kustomizecontroller.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should imagePullPolicy to be default value IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/charts/flux2/tests/notification-controller_test.yaml
+++ b/charts/flux2/tests/notification-controller_test.yaml
@@ -49,3 +49,15 @@ tests:
           path: spec.template.spec.containers[0].args
           content:
             --no-cross-namespace-refs=true
+  - it: should set imagePullPolicy to Always
+    set:
+      notificationcontroller.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should imagePullPolicy to be default value IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/charts/flux2/tests/source-controller_test.yaml
+++ b/charts/flux2/tests/source-controller_test.yaml
@@ -31,3 +31,15 @@ tests:
   - it: should match snapshot of default values
     asserts:
       - matchSnapshot: { }
+  - it: should set imagePullPolicy to Always
+    set:
+      sourcecontroller.imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should imagePullPolicy to be default value IfNotPresent
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -52,6 +52,7 @@ helmcontroller:
   serviceaccount:
     create: true
     annotations: {}
+  imagePullPolicy: {}
   nodeSelector: {}
   # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
   # for example:
@@ -96,6 +97,7 @@ imageautomationcontroller:
   serviceaccount:
     create: true
     annotations: {}
+  imagePullPolicy: {}
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -120,6 +122,7 @@ imagereflectorcontroller:
   serviceaccount:
     create: true
     annotations: {}
+  imagePullPolicy: {}
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -144,6 +147,7 @@ kustomizecontroller:
   serviceaccount:
     create: true
     annotations: {}
+  imagePullPolicy: {}
   secret:
     # -- Create a secret to use it with extraSecretMounts. Defaults to false.
     create: false
@@ -188,6 +192,7 @@ notificationcontroller:
   serviceaccount:
     create: true
     annotations: {}
+  imagePullPolicy: {}
   service:
     labels: {}
     annotations: {}
@@ -219,6 +224,7 @@ sourcecontroller:
   serviceaccount:
     create: true
     annotations: {}
+  imagePullPolicy: {}
   service:
     labels: {}
     annotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR allows users to select the imagePullPolicy for the controllers.
In most cases it's even recommended to run imagePullPolicy: Always for security reasons.
 
#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
