### PR TITLE
feat: add priorityclass

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.33.0
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Update]: Update App Version to upstream 0.33.0"
+    - "[Update]: Add ability to specify priorityclass"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.nodeSelector | object | `{}` |  |
 | cli.tag | string | `"v0.33.0"` |  |
 | cli.tolerations | list | `[]` |  |
-| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy.  In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
+| eventsaddr | string | `"http://notification-controller/"` | Maybe you need to use full domain name here, if you deploy flux in environments that use http proxy. In such environments they normally add `.cluster.local` and `.local` suffixes to `no_proxy` variable in order to prevent cluster-local traffic from going through http proxy. Without fully specified domain they need to mention `notifications-controller` explicitly in `no_proxy` variable after debugging http proxy logs eg: http://notification-controller.[NAMESPACE].svc.[CLUSTERDOMAIN] |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmcontroller.affinity | object | `{}` |  |
 | helmcontroller.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -29,6 +29,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmcontroller.image | string | `"ghcr.io/fluxcd/helm-controller"` |  |
 | helmcontroller.labels | object | `{}` |  |
 | helmcontroller.nodeSelector | object | `{}` |  |
+| helmcontroller.priorityClassName | string | `""` |  |
 | helmcontroller.resources.limits | object | `{}` |  |
 | helmcontroller.resources.requests.cpu | string | `"100m"` |  |
 | helmcontroller.resources.requests.memory | string | `"64Mi"` |  |
@@ -45,6 +46,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageautomationcontroller.image | string | `"ghcr.io/fluxcd/image-automation-controller"` |  |
 | imageautomationcontroller.labels | object | `{}` |  |
 | imageautomationcontroller.nodeSelector | object | `{}` |  |
+| imageautomationcontroller.priorityClassName | string | `""` |  |
 | imageautomationcontroller.resources.limits | object | `{}` |  |
 | imageautomationcontroller.resources.requests.cpu | string | `"100m"` |  |
 | imageautomationcontroller.resources.requests.memory | string | `"64Mi"` |  |
@@ -60,6 +62,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imagereflectorcontroller.image | string | `"ghcr.io/fluxcd/image-reflector-controller"` |  |
 | imagereflectorcontroller.labels | object | `{}` |  |
 | imagereflectorcontroller.nodeSelector | object | `{}` |  |
+| imagereflectorcontroller.priorityClassName | string | `""` |  |
 | imagereflectorcontroller.resources.limits | object | `{}` |  |
 | imagereflectorcontroller.resources.requests.cpu | string | `"100m"` |  |
 | imagereflectorcontroller.resources.requests.memory | string | `"64Mi"` |  |
@@ -78,6 +81,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizecontroller.image | string | `"ghcr.io/fluxcd/kustomize-controller"` |  |
 | kustomizecontroller.labels | object | `{}` |  |
 | kustomizecontroller.nodeSelector | object | `{}` |  |
+| kustomizecontroller.priorityClassName | string | `""` |  |
 | kustomizecontroller.resources.limits | object | `{}` |  |
 | kustomizecontroller.resources.requests.cpu | string | `"100m"` |  |
 | kustomizecontroller.resources.requests.memory | string | `"64Mi"` |  |
@@ -99,6 +103,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationcontroller.image | string | `"ghcr.io/fluxcd/notification-controller"` |  |
 | notificationcontroller.labels | object | `{}` |  |
 | notificationcontroller.nodeSelector | object | `{}` |  |
+| notificationcontroller.priorityClassName | string | `""` |  |
 | notificationcontroller.resources.limits | object | `{}` |  |
 | notificationcontroller.resources.requests.cpu | string | `"100m"` |  |
 | notificationcontroller.resources.requests.memory | string | `"64Mi"` |  |
@@ -122,6 +127,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourcecontroller.image | string | `"ghcr.io/fluxcd/source-controller"` |  |
 | sourcecontroller.labels | object | `{}` |  |
 | sourcecontroller.nodeSelector | object | `{}` |  |
+| sourcecontroller.priorityClassName | string | `""` |  |
 | sourcecontroller.resources.limits | object | `{}` |  |
 | sourcecontroller.resources.requests.cpu | string | `"100m"` |  |
 | sourcecontroller.resources.requests.memory | string | `"64Mi"` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -90,6 +90,9 @@ spec:
         {{- if .Values.helmcontroller.volumeMounts }}
         {{- toYaml .Values.helmcontroller.volumeMounts | nindent 8 }}
         {{- end}}
+      {{- if .Values.helmcontroller.priorityClassName }}
+      priorityClassName: {{ .Values.helmcontroller.priorityClassName | quote }}
+      {{- end }}
       serviceAccountName: helm-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -89,6 +89,9 @@ spec:
         {{- if .Values.imageautomationcontroller.volumeMounts }}
         {{- toYaml .Values.imageautomationcontroller.volumeMounts | nindent 8 }}
         {{- end}}
+      {{- if .Values.imageautomationcontroller.priorityClassName }}
+      priorityClassName: {{ .Values.imageautomationcontroller.priorityClassName | quote }}
+      {{- end }}
       securityContext:
         fsGroup: 1337
       serviceAccountName: image-automation-controller

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -91,6 +91,9 @@ spec:
         {{- if .Values.imagereflectorcontroller.volumeMounts }}
         {{- toYaml .Values.imagereflectorcontroller.volumeMounts | nindent 8 }}
         {{- end}}
+      {{- if .Values.imagereflectorcontroller.priorityClassName }}
+      priorityClassName: {{ .Values.imagereflectorcontroller.priorityClassName | quote }}
+      {{- end }}
       securityContext:
         fsGroup: 1337
       serviceAccountName: image-reflector-controller

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -101,6 +101,9 @@ spec:
         {{- if .Values.kustomizecontroller.volumeMounts }}
         {{- toYaml .Values.kustomizecontroller.volumeMounts | nindent 8 }}
         {{- end}}
+      {{- if .Values.kustomizecontroller.priorityClassName }}
+      priorityClassName: {{ .Values.kustomizecontroller.priorityClassName | quote }}
+      {{- end }}
       {{- range .Values.kustomizecontroller.extraSecretMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -95,6 +95,9 @@ spec:
         {{- if .Values.notificationcontroller.volumeMounts }}
         {{- toYaml .Values.notificationcontroller.volumeMounts | nindent 8 }}
         {{- end}}
+      {{- if .Values.notificationcontroller.priorityClassName }}
+      priorityClassName: {{ .Values.notificationcontroller.priorityClassName | quote }}
+      {{- end }}
       serviceAccountName: notification-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -99,6 +99,9 @@ spec:
         {{- if .Values.sourcecontroller.volumeMounts }}
         {{- toYaml .Values.sourcecontroller.volumeMounts | nindent 8 }}
         {{- end}}
+      {{- if .Values.sourcecontroller.priorityClassName }}
+      priorityClassName: {{ .Values.sourcecontroller.priorityClassName | quote }}
+      {{- end }}
       securityContext:
         fsGroup: 1337
       serviceAccountName: source-controller

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.0
+        helm.sh/chart: flux2-1.2.1
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.0
+        helm.sh/chart: flux2-1.2.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.0
+        helm.sh/chart: flux2-1.2.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
-        helm.sh/chart: flux2-1.2.0
+        helm.sh/chart: flux2-1.2.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.0
+        helm.sh/chart: flux2-1.2.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.0
+        helm.sh/chart: flux2-1.2.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.0
+        helm.sh/chart: flux2-1.2.1
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -43,6 +43,7 @@ helmcontroller:
     requests:
       cpu: 100m
       memory: 64Mi
+  priorityClassName: ""
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
@@ -87,6 +88,7 @@ imageautomationcontroller:
     requests:
       cpu: 100m
       memory: 64Mi
+  priorityClassName: ""
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
@@ -111,6 +113,7 @@ imagereflectorcontroller:
     requests:
       cpu: 100m
       memory: 64Mi
+  priorityClassName: ""
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
@@ -135,6 +138,7 @@ kustomizecontroller:
     requests:
       cpu: 100m
       memory: 64Mi
+  priorityClassName: ""
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
@@ -179,6 +183,7 @@ notificationcontroller:
     requests:
       cpu: 100m
       memory: 64Mi
+  priorityClassName: ""
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
@@ -210,6 +215,7 @@ sourcecontroller:
     requests:
       cpu: 100m
       memory: 64Mi
+  priorityClassName: ""
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the ability to specify a `priorityclass` per flux component.

> [Pods](https://kubernetes.io/docs/concepts/workloads/pods/) can have priority. Priority indicates the importance of a Pod relative to other Pods. If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority Pods to make scheduling of the pending Pod possible.

This is useful for flux because in most cases it is more important than other workloads. This PR allows the user to specify a priorityClassName per component.

#### Which issue this PR fixes
There is no issue for that.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
