### PR TITLE
Filter out non-running pods in Prometheus

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: 0.33.0
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Update]: Add ability to specify priorityclass"
+    - "[Update]: Filter out non-running pods in Prometheus"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.33.0](https://img.shields.io/badge/AppVersion-0.33.0-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -117,6 +117,10 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationcontroller.webhookReceiver.service.labels | object | `{}` |  |
 | policies.create | bool | `true` |  |
 | prometheus.podMonitor.create | bool | `false` |  |
+| prometheus.podMonitor.podMetricsEndpoints[0].port | string | `"http-prom"` |  |
+| prometheus.podMonitor.podMetricsEndpoints[0].relabelings[0].action | string | `"keep"` |  |
+| prometheus.podMonitor.podMetricsEndpoints[0].relabelings[0].regex | string | `"Running"` |  |
+| prometheus.podMonitor.podMetricsEndpoints[0].relabelings[0].sourceLabels[0] | string | `"__meta_kubernetes_pod_phase"` |  |
 | rbac.create | bool | `true` |  |
 | sourcecontroller.affinity | object | `{}` |  |
 | sourcecontroller.annotations."prometheus.io/port" | string | `"8080"` |  |

--- a/charts/flux2/templates/podmonitor.yaml
+++ b/charts/flux2/templates/podmonitor.yaml
@@ -28,5 +28,5 @@ spec:
           - image-automation-controller
           - image-reflector-controller
   podMetricsEndpoints:
-    - port: http-prom
+{{ toYaml .Values.prometheus.podMonitor.podMetricsEndpoints | indent 4 }}
 {{- end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.2.2
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.2.2
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.2.2
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.2.2
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.2.2
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.2.2
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.33.0
         control-plane: controller
-        helm.sh/chart: flux2-1.2.1
+        helm.sh/chart: flux2-1.2.2
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -275,3 +275,10 @@ extraObjects: []
 prometheus:
   podMonitor:
     create: false
+    podMetricsEndpoints:
+      - port: http-prom
+        relabelings:
+          # https://github.com/prometheus-operator/prometheus-operator/issues/4816
+          - sourceLabels: [__meta_kubernetes_pod_phase]
+            action: keep
+            regex: Running


### PR DESCRIPTION
Signed-off-by: Arcadie Condrat <arcadie.condrat@gmail.com>

<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Prometheus job generated by the `PodMonitor` does not exclude non-running pods. All the "completed" Pods are going to be  listed as targets in Prometheus and marked as down. This issue is related to `PodMonitor` implementation and is discussed in https://github.com/prometheus-operator/prometheus-operator/issues/4816

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:
N/A
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
