### PR TITLE
fix(ci): Set Helm version explicitly

### DIFF
--- a/.github/workflows/e2e-sync.yaml
+++ b/.github/workflows/e2e-sync.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Helm
         uses: fluxcd/pkg//actions/helm@main
         with:
-          version: 3.7.1
+          version: 3.10.1
       - name: Install
         run: |
           helm upgrade --install --debug flux2 ./charts/flux2 \

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: 3.*
+          version: 3.10.1
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: 3.*
+          version: 3.10.1
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1


### PR DESCRIPTION
Like in `e2e-sync.yaml`, set the Helm version explicitly for all workflows This is making PRs like https://github.com/fluxcd-community/helm-charts/pull/137 fail because the action is downloading an alpha version

Signed-off-by: Julien Duchesne <julien.duchesne@grafana.com>
