### PR TITLE
flux2: Directly link to changelog

### DIFF
--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -6,6 +6,10 @@ A Helm chart for flux2
 
 This helm chart is maintain and released by the fluxcd-community on a best effort basis.
 
+## Changelog
+
+View the [Changelog on artifacthub](https://artifacthub.io/packages/helm/fluxcd-community/flux2?modal=changelog).
+
 ## Source Code
 
 * <https://github.com/fluxcd-community/helm-charts>


### PR DESCRIPTION
It wasn't obvious for me where to find the changelog and it was important for the 2.0 refactor.