### PR TITLE
fix: ensure resource name is all lowercase

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: flux2
 description: A Helm chart for flux2
 type: application
-version: 2.1.0
+version: 2.1.1
 appVersion: 0.37.0
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 0.37.0"
+    - "[Chore]: Fix bug with multi-tenancy clusterrolebinding"

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -38,7 +38,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmController.serviceAccount.create | bool | `true` |  |
 | helmController.tag | string | `"v0.27.0"` |  |
 | helmController.tolerations | list | `[]` |  |
-| helmcontroller.tag | string | `"v0.27.0"` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | imageAutomationController.annotations."prometheus.io/scrape" | string | `"true"` |  |
@@ -55,7 +54,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
 | imageAutomationController.tag | string | `"v0.27.0"` |  |
-| imageAutomationController.tag | string | `"v0.26.1"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -75,8 +73,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
 | imageReflectionController.tag | string | `"v0.23.0"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
-| imageautomationcontroller.tag | string | `"v0.27.0"` |  |
-| imagereflectorcontroller.tag | string | `"v0.23.0"` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
 | kustomizeController.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -100,7 +96,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizeController.serviceAccount.create | bool | `true` |  |
 | kustomizeController.tag | string | `"v0.31.0"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
-| kustomizecontroller.tag | string | `"v0.31.0"` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
 | multitenancy.enabled | bool | `false` | Implement the patches for Multi-tenancy lockdown. See https://fluxcd.io/docs/installation/#multi-tenancy-lockdown |
@@ -126,7 +121,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.service.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.service.labels | object | `{}` |  |
-| notificationcontroller.tag | string | `"v0.29.0"` |  |
 | policies.create | bool | `true` |  |
 | prometheus.podMonitor.create | bool | `false` | Enables podMonitor endpoint |
 | prometheus.podMonitor.podMetricsEndpoints[0].port | string | `"http-prom"` |  |
@@ -154,5 +148,4 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourceController.serviceAccount.create | bool | `true` |  |
 | sourceController.tag | string | `"v0.32.1"` |  |
 | sourceController.tolerations | list | `[]` |  |
-| sourcecontroller.tag | string | `"v0.32.1"` |  |
 | watchAllNamespaces | bool | `true` |  |

--- a/charts/flux2/templates/cluster-reconciler-impersonator-clusterrole.yaml
+++ b/charts/flux2/templates/cluster-reconciler-impersonator-clusterrole.yaml
@@ -11,6 +11,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 rules:
 - apiGroups: [""]
-  resources: ["serviceAccounts"]
+  resources: ["serviceaccounts"]
   verbs: ["impersonate"]
 {{- end }}

--- a/charts/flux2/templates/crd-controller-clusterrole.yaml
+++ b/charts/flux2/templates/crd-controller-clusterrole.yaml
@@ -31,7 +31,7 @@ rules:
   - namespaces
   - secrets
   - configmaps
-  - serviceAccounts
+  - serviceaccounts
   verbs:
   - get
   - list

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.0
+        helm.sh/chart: flux2-2.1.1
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.0
+        helm.sh/chart: flux2-2.1.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.0
+        helm.sh/chart: flux2-2.1.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.1.0
+        helm.sh/chart: flux2-2.1.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.0
+        helm.sh/chart: flux2-2.1.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.0
+        helm.sh/chart: flux2-2.1.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.0
+        helm.sh/chart: flux2-2.1.1
       name: source-controller
     spec:
       replicas: 1


### PR DESCRIPTION
We're running with `multitenancy.enabled=true` and `multitenancy.privileged=false`. With 2.x.x we observe the following issue:

```
[...]  helm-controller  reconciliation failed: failed to get last release revision: query: failed to query with labels: 
    serviceaccounts "flux-admin" is forbidden: User "system:serviceaccount:flux-system:helm-controller" 
    cannot impersonate resource "serviceaccounts" in API group "" in the namespace "admin"
```

This is due to the role pointing to resource `serviceAccount` instead of `serviceaccount`.

#### What this PR does / why we need it:

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
