### PR TITLE
feat: Allow disabling CRDs for specific controllers

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
-apiVersion: v2
-name: flux2
-description: A Helm chart for flux2
-type: application
-version: 2.1.1
-appVersion: 0.37.0
-sources:
-  - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Fix bug with multi-tenancy clusterrolebinding"
+    - "[Added]: Allow disabling CRD installation for specific controllers"
+apiVersion: v2
+appVersion: 0.37.0
+description: A Helm chart for flux2
+name: flux2
+sources:
+- https://github.com/fluxcd-community/helm-charts
+type: application
+version: 2.2.0

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installCRDs }}
+{{- if and .Values.installCRDs .Values.helmController.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.installCRDs .Values.helmController.installCRDs }}
+{{- if and .Values.installCRDs .Values.helmController.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.installCRDs .Values.imageAutomationController.installCRDs }}
+{{- if and .Values.installCRDs .Values.imageAutomationController.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installCRDs }}
+{{- if and .Values.installCRDs .Values.imageAutomationController.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installCRDs }}
+{{- if and .Values.installCRDs .Values.imageReflectionController.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.installCRDs .Values.imageReflectionController.installCRDs }}
+{{- if and .Values.installCRDs .Values.imageReflectionController.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installCRDs }}
+{{- if and .Values.installCRDs .Values.kustomizeController.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.installCRDs .Values.kustomizeController.installCRDs }}
+{{- if and .Values.installCRDs .Values.kustomizeController.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.installCRDs .Values.notificationController.installCRDs }}
+{{- if and .Values.installCRDs .Values.notificationController.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installCRDs }}
+{{- if and .Values.installCRDs .Values.notificationController.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.installCRDs }}
+{{- if and .Values.installCRDs .Values.sourceController.installCRDs }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.installCRDs .Values.sourceController.installCRDs }}
+{{- if and .Values.installCRDs .Values.sourceController.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.1
+        helm.sh/chart: flux2-2.2.0
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.1
+        helm.sh/chart: flux2-2.2.0
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.1
+        helm.sh/chart: flux2-2.2.0
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.1.1
+        helm.sh/chart: flux2-2.2.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.1
+        helm.sh/chart: flux2-2.2.0
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.1
+        helm.sh/chart: flux2-2.2.0
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.1.1
+        helm.sh/chart: flux2-2.2.0
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -29,6 +29,7 @@ cli:
 
 helmController:
   create: true
+  installCRDs: true
   image: ghcr.io/fluxcd/helm-controller
   tag: v0.27.0
   resources:
@@ -75,6 +76,7 @@ helmController:
 
 imageAutomationController:
   create: true
+  installCRDs: true
   image: ghcr.io/fluxcd/image-automation-controller
   tag: v0.27.0
   resources:
@@ -101,6 +103,7 @@ imageAutomationController:
 
 imageReflectionController:
   create: true
+  installCRDs: true
   image: ghcr.io/fluxcd/image-reflector-controller
   tag: v0.23.0
   resources:
@@ -127,6 +130,7 @@ imageReflectionController:
 
 kustomizeController:
   create: true
+  installCRDs: true
   image: ghcr.io/fluxcd/kustomize-controller
   tag: v0.31.0
   resources:
@@ -173,6 +177,7 @@ kustomizeController:
 
 notificationController:
   create: true
+  installCRDs: true
   image: ghcr.io/fluxcd/notification-controller
   tag: v0.29.0
   resources:
@@ -206,6 +211,7 @@ notificationController:
 
 sourceController:
   create: true
+  installCRDs: true
   image: ghcr.io/fluxcd/source-controller
   tag: v0.32.1
   resources:

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -29,7 +29,6 @@ cli:
 
 helmController:
   create: true
-  installCRDs: true
   image: ghcr.io/fluxcd/helm-controller
   tag: v0.27.0
   resources:
@@ -76,7 +75,6 @@ helmController:
 
 imageAutomationController:
   create: true
-  installCRDs: true
   image: ghcr.io/fluxcd/image-automation-controller
   tag: v0.27.0
   resources:
@@ -103,7 +101,6 @@ imageAutomationController:
 
 imageReflectionController:
   create: true
-  installCRDs: true
   image: ghcr.io/fluxcd/image-reflector-controller
   tag: v0.23.0
   resources:
@@ -130,7 +127,6 @@ imageReflectionController:
 
 kustomizeController:
   create: true
-  installCRDs: true
   image: ghcr.io/fluxcd/kustomize-controller
   tag: v0.31.0
   resources:
@@ -177,7 +173,6 @@ kustomizeController:
 
 notificationController:
   create: true
-  installCRDs: true
   image: ghcr.io/fluxcd/notification-controller
   tag: v0.29.0
   resources:
@@ -211,7 +206,6 @@ notificationController:
 
 sourceController:
   create: true
-  installCRDs: true
   image: ghcr.io/fluxcd/source-controller
   tag: v0.32.1
   resources:

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -10,6 +10,12 @@ delete_temp_dir() {
 }
 trap delete_temp_dir EXIT
 
+
+get_controller_values_attribute() {
+  echo "$(echo $1 | cut -d '/' -f5 | sed 's/reflector/reflection/' | sed 's/-./\U&/g' | tr -d '-')"
+}
+
+
 for FILE in `cat .work/flux2/manifests/crds/kustomization.yaml | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*"`
 do
 
@@ -38,7 +44,8 @@ transformers:
    - global-labels.yaml
 EOF
 
-echo "{{- if .Values.installCRDs }}" > ./charts/flux2/templates/${FILE##*/}
+attribute="$(get_controller_values_attribute ${FILE})"
+echo "{{- if and .Values.installCRDs .Values.${attribute}.installCRDs }}" > ./charts/flux2/templates/${FILE##*/}
 kubectl kustomize "${TEMPDIR}" >> ./charts/flux2/templates/${FILE##*/}
 echo "{{- end }}">> ./charts/flux2/templates/${FILE##*/}
 
@@ -53,7 +60,8 @@ done
 for FILE in `cat .work/flux2/manifests/crds/kustomization.yaml | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*"`
 do
 
-diff -B ./charts/flux2/values.yaml <(controllerName=`echo $FILE | cut -d '/' -f5 | tr -d '-'`  controllerVersion=`echo $FILE | cut -d '/' -f8`  yq eval '.[env(controllerName)].tag = env(controllerVersion)' ./charts/flux2/values.yaml) | patch ./charts/flux2/values.yaml
+attribute="$(get_controller_values_attribute ${FILE})"
+diff -B ./charts/flux2/values.yaml <(controllerName="${attribute}"  controllerVersion=`echo $FILE | cut -d '/' -f8`  yq eval '.[env(controllerName)].tag = env(controllerVersion)' ./charts/flux2/values.yaml) | patch ./charts/flux2/values.yaml
 
 # update unittest snapshots
 controllerName=`echo $FILE | cut -d '/' -f5`

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -45,7 +45,7 @@ transformers:
 EOF
 
 attribute="$(get_controller_values_attribute ${FILE})"
-echo "{{- if and .Values.installCRDs .Values.${attribute}.installCRDs }}" > ./charts/flux2/templates/${FILE##*/}
+echo "{{- if and .Values.installCRDs .Values.${attribute}.create }}" > ./charts/flux2/templates/${FILE##*/}
 kubectl kustomize "${TEMPDIR}" >> ./charts/flux2/templates/${FILE##*/}
 echo "{{- end }}">> ./charts/flux2/templates/${FILE##*/}
 


### PR DESCRIPTION
Currently, `installCRDs` is a global flag and there's no way to only install CRDs for certain controllers 
This PR adds another level (true by default for retrocompatibility) that can be used to disable CRD installation for a specific controller

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
