### PR TITLE
ExtraEnv support for all controller deployments

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Allow disabling CRD installation for specific controllers"
+    - "[Added]: Support passing in extraEnv variables to all flux controllers"
 apiVersion: v2
 appVersion: 0.37.0
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.2.0
+version: 2.3.0

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -26,6 +26,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | helmController.container.additionalArgs | list | `[]` |  |
 | helmController.create | bool | `true` |  |
+| helmController.extraEnv | list | `[]` |  |
 | helmController.image | string | `"ghcr.io/fluxcd/helm-controller"` |  |
 | helmController.imagePullPolicy | object | `{}` |  |
 | helmController.labels | object | `{}` |  |
@@ -80,6 +81,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizeController.container.additionalArgs | list | `[]` |  |
 | kustomizeController.create | bool | `true` |  |
 | kustomizeController.envFrom | object | `{"map":{"name":""},"secret":{"name":""}}` | Defines envFrom using a configmap and/or secret. |
+| kustomizeController.extraEnv | list | `[]` |  |
 | kustomizeController.extraSecretMounts | list | `[]` | Defines additional mounts with secrets. Secrets must be manually created in the namespace or with kustomizeController.secret |
 | kustomizeController.image | string | `"ghcr.io/fluxcd/kustomize-controller"` |  |
 | kustomizeController.imagePullPolicy | object | `{}` |  |
@@ -105,6 +107,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | notificationController.container.additionalArgs | list | `[]` |  |
 | notificationController.create | bool | `true` |  |
+| notificationController.extraEnv | list | `[]` |  |
 | notificationController.image | string | `"ghcr.io/fluxcd/notification-controller"` |  |
 | notificationController.imagePullPolicy | object | `{}` |  |
 | notificationController.labels | object | `{}` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -49,6 +49,9 @@ spec:
         - {{ . }}
         {{- end}}
         env:
+        {{- with .Values.sourceController.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: RUNTIME_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -55,6 +55,10 @@ spec:
               fieldPath: metadata.namespace
         {{- if or (.Values.kustomizeController.envFrom.map.name) (.Values.kustomizeController.envFrom.secret.name) }}
         envFrom:
+          {{- with .Values.kustomizeController.extraEnv }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+
           {{- if .Values.kustomizeController.envFrom.map.name }}
           - configMapRef:
               name: {{ .Values.kustomizeController.envFrom.map.name }}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -45,6 +45,9 @@ spec:
         - {{ . }}
         {{- end}}
         env:
+        {{- with .Values.notificationController.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: RUNTIME_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -50,6 +50,7 @@ helmController:
     annotations: {}
   imagePullPolicy: {}
   nodeSelector: {}
+  extraEnv: []
   # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
   # for example:
   #   affinity:
@@ -170,6 +171,7 @@ kustomizeController:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  extraEnv: []
 
 notificationController:
   create: true
@@ -203,6 +205,7 @@ notificationController:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  extraEnv: []
 
 sourceController:
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Support passing in extraEnv variables to helmController, notificationController, kustomizationController, sourceController

#### Which issue this PR fixes
  - fixes #146


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
