### PR TITLE
Introduce support for specifying annotations for the pre-install-job

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,8 @@
 annotations:
   artifacthub.io/changes: |
+    - "[Added]: Allow disabling CRD installation for specific controllers"
     - "[Added]: Allow setting automountServiceAccountToken on the pod spec"
+    - "[Added]: Support specifying annotationts for the pre-install-job"
 apiVersion: v2
 appVersion: 0.37.0
 description: A Helm chart for flux2
@@ -8,4 +10,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.3.0
+version: 2.4.0

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -15,6 +15,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cli.affinity | object | `{}` |  |
+| cli.annotations | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.tag | string | `"v0.37.0"` |  |

--- a/charts/flux2/templates/pre-install-job.yaml
+++ b/charts/flux2/templates/pre-install-job.yaml
@@ -17,6 +17,9 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}"
+      {{- with .Values.cli.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.3.0
+        helm.sh/chart: flux2-2.4.0
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.3.0
+        helm.sh/chart: flux2-2.4.0
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.3.0
+        helm.sh/chart: flux2-2.4.0
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.3.0
+        helm.sh/chart: flux2-2.4.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.3.0
+        helm.sh/chart: flux2-2.4.0
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.3.0
+        helm.sh/chart: flux2-2.4.0
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.3.0
+        helm.sh/chart: flux2-2.4.0
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/pre-install-job_test.yaml
+++ b/charts/flux2/tests/pre-install-job_test.yaml
@@ -1,0 +1,36 @@
+suite: test pre-install-job hook
+templates:
+  - pre-install-job.yaml
+tests:
+  - it: should have no annotations added by default
+    asserts:
+      - isEmpty:
+          path: spec.template.metadata.annotations
+  - it: should have added annotation
+    set:
+      cli:
+        annotations:
+          name1: value1
+    asserts:
+      - isNotEmpty:
+          path: spec.template.metadata.annotations
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            name1: value1  
+  - it: should have added annotations
+    set:
+      cli:
+        annotations:
+          name1: value1
+          name2: value2
+          name3: value3
+    asserts:
+      - isNotEmpty:
+          path: spec.template.metadata.annotations
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            name1: value1  
+            name2: value2
+            name3: value3

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -24,6 +24,7 @@ cli:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  annotations: {}
 
 # controllers
 


### PR DESCRIPTION
Addresses issue #145

Signed-off-by: Russell Yardley <russell.yardley@finastra.com>

<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR introduces support for specifying annotations for the pre-install-job.  This addresses issue #145.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #145

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
