### PR TITLE
feat: allow setting automountServiceAccountToken in pod spec

### DIFF
--- a/.github/workflows/e2e-sync.yaml
+++ b/.github/workflows/e2e-sync.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: engineerd/setup-kind@v0.5.0
         with:
           version: v0.11.1
-          image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          image: kindest/node:v1.23.13@sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
       - name: Setup Helm
         uses: fluxcd/pkg//actions/helm@main
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -35,7 +35,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm env
-          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.8
+          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.11
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Allow disabling CRD installation for specific controllers"
+    - "[Added]: Allow setting automountServiceAccountToken on the pod spec"
 apiVersion: v2
 appVersion: 0.37.0
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.2.0
+version: 2.3.0

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -35,6 +35,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmController.resources.requests.cpu | string | `"100m"` |  |
 | helmController.resources.requests.memory | string | `"64Mi"` |  |
 | helmController.serviceAccount.annotations | object | `{}` |  |
+| helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
 | helmController.tag | string | `"v0.27.0"` |  |
 | helmController.tolerations | list | `[]` |  |
@@ -52,6 +53,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageAutomationController.resources.requests.cpu | string | `"100m"` |  |
 | imageAutomationController.resources.requests.memory | string | `"64Mi"` |  |
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
+| imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
 | imageAutomationController.tag | string | `"v0.27.0"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
@@ -70,6 +72,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageReflectionController.resources.requests.cpu | string | `"100m"` |  |
 | imageReflectionController.resources.requests.memory | string | `"64Mi"` |  |
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
+| imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
 | imageReflectionController.tag | string | `"v0.23.0"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
@@ -93,6 +96,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizeController.secret.data | object | `{}` |  |
 | kustomizeController.secret.name | string | `""` |  |
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
+| kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
 | kustomizeController.tag | string | `"v0.31.0"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
@@ -116,6 +120,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationController.service.annotations | object | `{}` |  |
 | notificationController.service.labels | object | `{}` |  |
 | notificationController.serviceAccount.annotations | object | `{}` |  |
+| notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
 | notificationController.tag | string | `"v0.29.0"` |  |
 | notificationController.tolerations | list | `[]` |  |
@@ -145,6 +150,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourceController.service.annotations | object | `{}` |  |
 | sourceController.service.labels | object | `{}` |  |
 | sourceController.serviceAccount.annotations | object | `{}` |  |
+| sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
 | sourceController.tag | string | `"v0.32.1"` |  |
 | sourceController.tolerations | list | `[]` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -28,6 +28,7 @@ spec:
         app: helm-controller
 {{ with .Values.helmController.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
+      automountServiceAccountToken: {{ .Values.helmController.serviceAccount.automount }}
     {{- if .Values.helmController.initContainers}}
       initContainers:
         {{- toYaml .Values.helmController.initContainers | nindent 8}}

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -28,6 +28,7 @@ spec:
         app: image-automation-controller
 {{ with .Values.imageAutomationController.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
+      automountServiceAccountToken: {{ .Values.imageAutomationController.serviceAccount.automount }}
       {{- if .Values.imageAutomationController.initContainers}}
       initContainers:
         {{- toYaml .Values.imageAutomationController.initContainers | nindent 8}}

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -28,6 +28,7 @@ spec:
         app: image-reflector-controller
 {{ with .Values.imageReflectionController.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
+      automountServiceAccountToken: {{ .Values.imageReflectionController.serviceAccount.automount }}
       {{- if .Values.imageReflectionController.initContainers}}
       initContainers:
         {{- toYaml .Values.imageReflectionController.initContainers | nindent 8}}

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -28,6 +28,7 @@ spec:
         app: kustomize-controller
 {{ with .Values.kustomizeController.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
+      automountServiceAccountToken: {{ .Values.kustomizeController.serviceAccount.automount }}
       {{- if .Values.kustomizeController.initContainers}}
       initContainers:
         {{- toYaml .Values.kustomizeController.initContainers | nindent 8}}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -28,6 +28,7 @@ spec:
         app: notification-controller
 {{ with .Values.notificationController.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
+      automountServiceAccountToken: {{ .Values.notificationController.serviceAccount.automount }}
       {{- if .Values.notificationController.initContainers}}
       initContainers:
         {{- toYaml .Values.notificationController.initContainers | nindent 8}}

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -30,6 +30,7 @@ spec:
         app: source-controller
 {{ with .Values.sourceController.labels }}{{ toYaml . | indent 8 }}{{ end }}
     spec:
+      automountServiceAccountToken: {{ .Values.sourceController.serviceAccount.automount }}
       {{- if .Values.sourceController.initContainers}}
       initContainers:
         {{- toYaml .Values.sourceController.initContainers | nindent 8}}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: helm-controller
     spec:
       replicas: 1
@@ -26,6 +26,7 @@ should match snapshot of default values:
             labeltestkey: labeltestvalue
             labeltestkey2: labeltestvalue2
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: image-automation-controller
     spec:
       replicas: 1
@@ -24,6 +24,7 @@ should match snapshot of default values:
           labels:
             app: image-automation-controller
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -24,6 +24,7 @@ should match snapshot of default values:
           labels:
             app: image-reflector-controller
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: kustomize-controller
     spec:
       replicas: 1
@@ -24,6 +24,7 @@ should match snapshot of default values:
           labels:
             app: kustomize-controller
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: notification-controller
     spec:
       replicas: 1
@@ -24,6 +24,7 @@ should match snapshot of default values:
           labels:
             app: notification-controller
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --watch-all-namespaces=true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.2.0
+        helm.sh/chart: flux2-2.3.0
       name: source-controller
     spec:
       replicas: 1
@@ -26,6 +26,7 @@ should match snapshot of default values:
           labels:
             app: source-controller
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -47,6 +47,7 @@ helmController:
     additionalArgs: []
   serviceAccount:
     create: true
+    automount: true
     annotations: {}
   imagePullPolicy: {}
   nodeSelector: {}
@@ -93,6 +94,7 @@ imageAutomationController:
     additionalArgs: []
   serviceAccount:
     create: true
+    automount: true
     annotations: {}
   imagePullPolicy: {}
   nodeSelector: {}
@@ -119,6 +121,7 @@ imageReflectionController:
     additionalArgs: []
   serviceAccount:
     create: true
+    automount: true
     annotations: {}
   imagePullPolicy: {}
   nodeSelector: {}
@@ -145,6 +148,7 @@ kustomizeController:
     additionalArgs: []
   serviceAccount:
     create: true
+    automount: true
     annotations: {}
   imagePullPolicy: {}
   secret:
@@ -191,6 +195,7 @@ notificationController:
     additionalArgs: []
   serviceAccount:
     create: true
+    automount: true
     annotations: {}
   imagePullPolicy: {}
   service:
@@ -224,6 +229,7 @@ sourceController:
     additionalArgs: []
   serviceAccount:
     create: true
+    automount: true
     annotations: {}
   imagePullPolicy: {}
   service:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows the user to set the `automountServiceAccountToken` in the pod spec. This is a well-known requirement for `CIS`, `BSI` and `NSA` security benchmarks.

The user is supposed to set `serviceAccount.automount=false` and must add the appropriate volumes/volumeMounts.

We probably **shouldn't** set the default to `serviceAccount.automount=false` and provide the necessary volumes/volumeMounts as this would be a breaking change. E.g. if a user supplied a custom `initContainer` this would now be launched without a service account mounted.

#### Which issue this PR fixes
- 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
