### PR TITLE
:sparkles: install-job: allow setting securityContext/volumes/volumeM…

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,8 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Allow disabling CRD installation for specific controllers"
-    - "[Added]: Allow setting automountServiceAccountToken on the pod spec"
-    - "[Added]: Support specifying annotationts for the pre-install-job"
+    - "[Added]: Allow setting install-job securityContext and volumes"
 apiVersion: v2
 appVersion: 0.37.0
 description: A Helm chart for flux2
@@ -10,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.4.0
+version: 2.4.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
+![Version: 2.4.1](https://img.shields.io/badge/Version-2.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -18,6 +18,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.annotations | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
+| cli.serviceAccount.automount | bool | `true` |  |
 | cli.tag | string | `"v0.37.0"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |

--- a/charts/flux2/templates/pre-install-job.yaml
+++ b/charts/flux2/templates/pre-install-job.yaml
@@ -29,13 +29,38 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: "{{ .Release.Name }}-flux-check"
+      automountServiceAccountToken: {{ .Values.cli.serviceAccount.automount }}
       containers:
       - name: flux-cli
         image: {{ template "template.image" .Values.cli }}
         command: ["/usr/local/bin/flux", "check",  "--pre", "--namespace", {{ .Release.Namespace }}]
+        {{- with .Values.cli.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.cli.securityContext }}
+        securityContext: {{ toYaml .Values.cli.securityContext | nindent 10 }}
+        {{- else }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        {{- end}}
+        {{- if .Values.cli.volumeMounts }}
+        volumeMounts:
+        {{- toYaml .Values.cli.volumeMounts | nindent 10 }}
+        {{- end}}
       {{- with .Values.cli.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.cli.volumes }}
+      volumes:
+      {{- toYaml .Values.cli.volumes | nindent 8 }}
+      {{- end}}
       {{- with .Values.cli.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.0
+        helm.sh/chart: flux2-2.4.1
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.0
+        helm.sh/chart: flux2-2.4.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.0
+        helm.sh/chart: flux2-2.4.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.4.0
+        helm.sh/chart: flux2-2.4.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.0
+        helm.sh/chart: flux2-2.4.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.0
+        helm.sh/chart: flux2-2.4.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -1,0 +1,49 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+        helm.sh/hook-weight: "-5"
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: flux
+        app.kubernetes.io/version: 0.37.0
+        helm.sh/chart: flux2-2.4.1
+      name: RELEASE-NAME-flux-check
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: NAMESPACE
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/part-of: flux
+            app.kubernetes.io/version: 0.37.0
+            helm.sh/chart: flux2-2.4.1
+          name: RELEASE-NAME
+        spec:
+          automountServiceAccountToken: true
+          containers:
+          - command:
+            - /usr/local/bin/flux
+            - check
+            - --pre
+            - --namespace
+            - NAMESPACE
+            image: ghcr.io/fluxcd/flux-cli:v0.37.0
+            name: flux-cli
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+          restartPolicy: Never
+          serviceAccountName: RELEASE-NAME-flux-check

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.0
+        helm.sh/chart: flux2-2.4.1
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/pre-install-job_test.yaml
+++ b/charts/flux2/tests/pre-install-job_test.yaml
@@ -17,7 +17,7 @@ tests:
       - equal:
           path: spec.template.metadata.annotations
           value:
-            name1: value1  
+            name1: value1
   - it: should have added annotations
     set:
       cli:
@@ -31,6 +31,74 @@ tests:
       - equal:
           path: spec.template.metadata.annotations
           value:
-            name1: value1  
+            name1: value1
             name2: value2
             name3: value3
+  - it: should set automount service account token
+    set:
+      cli.serviceAccount.automount: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+  - it: should set resource requests and limits
+    set:
+      cli.resources:
+        limits:
+          cpu: 300m
+          memory: 1024Mi
+        requests:
+          cpu: 300m
+          memory: 1024Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 300m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1024Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 300m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1024Mi
+  - it: should override securityContext
+    set:
+      cli.securityContext: {}
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value: null
+  - it: should set volumes
+    set:
+      cli.volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: serviceaccount-token
+      cli.volumes:
+        - name: serviceaccount-token
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                name: kube-root-ca.crt
+                items:
+                - key: ca.crt
+                  path: ca.crt
+            - downwardAPI:
+                items:
+                - path: namespace
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.volumes
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].volumeMounts
+  - it: should match snapshot of default values
+    asserts:
+      - matchSnapshot: {}

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -25,6 +25,8 @@ cli:
   affinity: {}
   tolerations: []
   annotations: {}
+  serviceAccount:
+    automount: true
 
 # controllers
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This is a follow-up of #149.
It allows users to set the pod's `securityContext`, `volumes`, `automountServiceAccountToken` as well as container `volumeMounts` on the install-job pod.
This can be used so that workloads conform with `CIS`, `BSI` or `NSA` security standards.

Proof of work
1. most of it is included in unittests
2. i ran a manual test to the installation procedure, see below


I modified the values like this:
```diff
diff --git a/charts/flux2/values.yaml b/charts/flux2/values.yaml
index 4815528..e73fb54 100644
--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -25,7 +25,29 @@ cli:
   affinity: {}
   tolerations: []
   serviceAccount:
-    automount: true
+    automount: false
+  volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: serviceaccount-token
+  volumes:
+    - name: serviceaccount-token
+      projected:
+        defaultMode: 420
+        sources:
+        - serviceAccountToken:
+            expirationSeconds: 3607
+            path: token
+        - configMap:
+            name: kube-root-ca.crt
+            items:
+            - key: ca.crt
+              path: ca.crt
+        - downwardAPI:
+            items:
+            - path: namespace
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
```

Then did a `helm template . | tee flux.install.yaml | kubectl apply -f -`. here a extract from the install job yaml:
<img width="1209" alt="Screenshot 2023-01-16 at 15 15 54" src="https://user-images.githubusercontent.com/100202497/212699342-0255541a-2273-40e3-929c-e43681e041c2.png">

Installation went smoothly, pods are up and running:
<img width="845" alt="Screenshot 2023-01-16 at 15 17 28" src="https://user-images.githubusercontent.com/100202497/212699373-280b6305-cccb-4cf8-a3d9-1a85cb978e27.png">


#### Which issue this PR fixes
- 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
