### PR TITLE
feat: allow setting PodSecurityContext for controllers

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Allow setting install-job securityContext and volumes"
+    - "[Added]: Allow setting podSecurityContext for controllers"
 apiVersion: v2
 appVersion: 0.37.0
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.4.1
+version: 2.5.0

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.4.1](https://img.shields.io/badge/Version-2.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -100,6 +100,9 @@ spec:
       {{- if .Values.helmController.priorityClassName }}
       priorityClassName: {{ .Values.helmController.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.helmController.podSecurityContext }}
+      securityContext: {{ toYaml .Values.helmController.podSecurityContext | nindent 8 }}
+      {{- end }}
       serviceAccountName: helm-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -99,8 +99,12 @@ spec:
       {{- if .Values.imageAutomationController.priorityClassName }}
       priorityClassName: {{ .Values.imageAutomationController.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.imageAutomationController.podSecurityContext }}
+      securityContext: {{ toYaml .Values.imageAutomationController.podSecurityContext | nindent 8 }}
+      {{- else }}
       securityContext:
         fsGroup: 1337
+      {{- end}}
       serviceAccountName: image-automation-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -101,8 +101,12 @@ spec:
       {{- if .Values.imageReflectionController.priorityClassName }}
       priorityClassName: {{ .Values.imageReflectionController.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.imageReflectionController.podSecurityContext }}
+      securityContext: {{ toYaml .Values.imageReflectionController.podSecurityContext | nindent 8 }}
+      {{- else }}
       securityContext:
         fsGroup: 1337
+      {{- end}}
       serviceAccountName: image-reflector-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -117,8 +117,12 @@ spec:
           subPath: {{ .subPath }}
           readOnly: {{ .readOnly }}
       {{- end }}
+      {{- if .Values.kustomizeController.podSecurityContext }}
+      securityContext: {{ toYaml .Values.kustomizeController.podSecurityContext | nindent 8 }}
+      {{- else }}
       securityContext:
         fsGroup: 1337
+      {{- end}}
       serviceAccountName: kustomize-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -103,6 +103,9 @@ spec:
       {{- if .Values.notificationController.priorityClassName }}
       priorityClassName: {{ .Values.notificationController.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.notificationController.podSecurityContext }}
+      securityContext: {{ toYaml .Values.notificationController.podSecurityContext | nindent 8 }}
+      {{- end }}
       serviceAccountName: notification-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -109,8 +109,12 @@ spec:
       {{- if .Values.sourceController.priorityClassName }}
       priorityClassName: {{ .Values.sourceController.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.sourceController.podSecurityContext }}
+      securityContext: {{ toYaml .Values.sourceController.podSecurityContext | nindent 8 }}
+      {{- else }}
       securityContext:
         fsGroup: 1337
+      {{- end}}
       serviceAccountName: source-controller
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 0.37.0
-            helm.sh/chart: flux2-2.4.1
+            helm.sh/chart: flux2-2.5.0
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.4.1
+        helm.sh/chart: flux2-2.5.0
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/helm-controller_test.yaml
+++ b/charts/flux2/tests/helm-controller_test.yaml
@@ -85,3 +85,18 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.custom.domain.
+  - it: should override securityContext
+    set:
+      helmController.podSecurityContext:
+        runAsUser: 2000
+      helmController.securityContext:
+        runAsUser: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 3000

--- a/charts/flux2/tests/image-automation-controller_test.yaml
+++ b/charts/flux2/tests/image-automation-controller_test.yaml
@@ -73,3 +73,18 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.custom.domain.
+  - it: should override securityContext
+    set:
+      imageAutomationController.podSecurityContext:
+        runAsUser: 2000
+      imageAutomationController.securityContext:
+        runAsUser: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 3000

--- a/charts/flux2/tests/image-reflector-controller_test.yaml
+++ b/charts/flux2/tests/image-reflector-controller_test.yaml
@@ -74,3 +74,18 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.custom.domain.
+  - it: should override securityContext
+    set:
+      imageReflectionController.podSecurityContext:
+        runAsUser: 2000
+      imageReflectionController.securityContext:
+        runAsUser: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 3000

--- a/charts/flux2/tests/kustomize-controller_test.yaml
+++ b/charts/flux2/tests/kustomize-controller_test.yaml
@@ -77,3 +77,18 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.custom.domain.
+  - it: should override securityContext
+    set:
+      kustomizeController.podSecurityContext:
+        runAsUser: 2000
+      kustomizeController.securityContext:
+        runAsUser: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 3000

--- a/charts/flux2/tests/notification-controller_test.yaml
+++ b/charts/flux2/tests/notification-controller_test.yaml
@@ -59,3 +59,18 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
+  - it: should override securityContext
+    set:
+      notificationController.podSecurityContext:
+        runAsUser: 2000
+      notificationController.securityContext:
+        runAsUser: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 3000

--- a/charts/flux2/tests/pre-install-job_test.yaml
+++ b/charts/flux2/tests/pre-install-job_test.yaml
@@ -65,11 +65,13 @@ tests:
           value: 1024Mi
   - it: should override securityContext
     set:
-      cli.securityContext: {}
+      cli.securityContext:
+        runAsNonRoot: false
     asserts:
       - equal:
-          path: spec.template.spec.securityContext
-          value: null
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsNonRoot: false
   - it: should set volumes
     set:
       cli.volumeMounts:

--- a/charts/flux2/tests/source-controller_test.yaml
+++ b/charts/flux2/tests/source-controller_test.yaml
@@ -56,3 +56,18 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.custom.domain.
+  - it: should override securityContext
+    set:
+      sourceController.podSecurityContext:
+        runAsUser: 2000
+      sourceController.securityContext:
+        runAsUser: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            runAsUser: 3000


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Setting the `securityContext` for containers of controller pods is already possible via the `*controller.securityContext` values. This PR allows setting the pod-level `securityContext` via setting the `*controller.podSecurityContext` values.

Note: this naming (`securityContext` and `podSecurityContext`) is in line with how the Kubernetes API is referring to [SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core) and [PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#podsecuritycontext-v1-core).

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
