### PR TITLE
fix(flux2): fix readiness probe port and path for source ctrl

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.5.1
+version: 2.5.2

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
+![Version: 2.5.2](https://img.shields.io/badge/Version-2.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.37.0](https://img.shields.io/badge/AppVersion-0.37.0-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -80,8 +80,8 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /
-            port: http
+            path: /readyz
+            port: healthz
         {{- with .Values.sourceController.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 0.37.0
-            helm.sh/chart: flux2-2.5.1
+            helm.sh/chart: flux2-2.5.2
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 0.37.0
         control-plane: controller
-        helm.sh/chart: flux2-2.5.1
+        helm.sh/chart: flux2-2.5.2
       name: source-controller
     spec:
       replicas: 1
@@ -60,8 +60,8 @@ should match snapshot of default values:
               protocol: TCP
             readinessProbe:
               httpGet:
-                path: /
-                port: http
+                path: /readyz
+                port: healthz
             resources:
               limits: {}
               requests:


### PR DESCRIPTION
fix: set right port and path for readiness probe

Signed-off-by: Ronan <ronan.souza@wildlifestudios.com>

<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
It fixes the readiness probe for the source controller in the flux2 chart. Currently, the chart is using the wrong port and path for the readiness probe causing non-leader source controller pods to keep in a not-ready state indefinitely.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] helm-docs are updated
- [ ] Helm chart is tested
- [ ] Update artifacthub.io/changes in Chart.yaml
- [ ] Run `make reviewable`
