### PR TITLE
chore/update to 2.0.0-rc.3 app version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v0.41.1
+FLUX2_VERSION ?= v2.0.0-rc.3
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-multi-tenancy/tests/__snapshot__/kyverno-policy_test.yaml.snap
+++ b/charts/flux2-multi-tenancy/tests/__snapshot__/kyverno-policy_test.yaml.snap
@@ -14,61 +14,61 @@ should match snapshot of default values:
       namespace: NAMESPACE
     spec:
       rules:
-      - exclude:
-          resources:
-            namespaces:
-            - flux-system
-        match:
-          resources:
-            kinds:
-            - Kustomization
-            - HelmRelease
-        name: serviceAccountName
-        validate:
-          message: .spec.serviceAccountName is required
-          pattern:
-            spec:
-              serviceAccountName: ?*
-      - exclude:
-          resources:
-            namespaces:
-            - flux-system
-        match:
-          resources:
-            kinds:
-            - Kustomization
-        name: kustomizationSourceRefNamespace
-        preconditions:
-          any:
-          - key: '{{request.object.spec.sourceRef.namespace}}'
-            operator: NotEquals
-            value: ""
-        validate:
-          deny:
-            conditions:
-            - key: '{{request.object.spec.sourceRef.namespace}}'
-              operator: NotEquals
-              value: '{{request.object.metadata.namespace}}'
-          message: .spec.sourceRef.namespace must be the same as metadata.namespace
-      - exclude:
-          resources:
-            namespaces:
-            - flux-system
-        match:
-          resources:
-            kinds:
-            - HelmRelease
-        name: helmReleaseSourceRefNamespace
-        preconditions:
-          any:
-          - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
-            operator: NotEquals
-            value: ""
-        validate:
-          deny:
-            conditions:
-            - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
-              operator: NotEquals
-              value: '{{request.object.metadata.namespace}}'
-          message: .spec.chart.spec.sourceRef.namespace must be the same as metadata.namespace
+        - exclude:
+            resources:
+              namespaces:
+                - flux-system
+          match:
+            resources:
+              kinds:
+                - Kustomization
+                - HelmRelease
+          name: serviceAccountName
+          validate:
+            message: .spec.serviceAccountName is required
+            pattern:
+              spec:
+                serviceAccountName: ?*
+        - exclude:
+            resources:
+              namespaces:
+                - flux-system
+          match:
+            resources:
+              kinds:
+                - Kustomization
+          name: kustomizationSourceRefNamespace
+          preconditions:
+            any:
+              - key: '{{request.object.spec.sourceRef.namespace}}'
+                operator: NotEquals
+                value: ""
+          validate:
+            deny:
+              conditions:
+                - key: '{{request.object.spec.sourceRef.namespace}}'
+                  operator: NotEquals
+                  value: '{{request.object.metadata.namespace}}'
+            message: .spec.sourceRef.namespace must be the same as metadata.namespace
+        - exclude:
+            resources:
+              namespaces:
+                - flux-system
+          match:
+            resources:
+              kinds:
+                - HelmRelease
+          name: helmReleaseSourceRefNamespace
+          preconditions:
+            any:
+              - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+                operator: NotEquals
+                value: ""
+          validate:
+            deny:
+              conditions:
+                - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+                  operator: NotEquals
+                  value: '{{request.object.metadata.namespace}}'
+            message: .spec.chart.spec.sourceRef.namespace must be the same as metadata.namespace
       validationFailureAction: enforce

--- a/charts/flux2-multi-tenancy/tests/__snapshot__/kyverno-policy_test.yaml.snap
+++ b/charts/flux2-multi-tenancy/tests/__snapshot__/kyverno-policy_test.yaml.snap
@@ -14,61 +14,61 @@ should match snapshot of default values:
       namespace: NAMESPACE
     spec:
       rules:
-        - exclude:
-            resources:
-              namespaces:
-                - flux-system
-          match:
-            resources:
-              kinds:
-                - Kustomization
-                - HelmRelease
-          name: serviceAccountName
-          validate:
-            message: .spec.serviceAccountName is required
-            pattern:
-              spec:
-                serviceAccountName: ?*
-        - exclude:
-            resources:
-              namespaces:
-                - flux-system
-          match:
-            resources:
-              kinds:
-                - Kustomization
-          name: kustomizationSourceRefNamespace
-          preconditions:
-            any:
-              - key: '{{request.object.spec.sourceRef.namespace}}'
-                operator: NotEquals
-                value: ""
-          validate:
-            deny:
-              conditions:
-                - key: '{{request.object.spec.sourceRef.namespace}}'
-                  operator: NotEquals
-                  value: '{{request.object.metadata.namespace}}'
-            message: .spec.sourceRef.namespace must be the same as metadata.namespace
-        - exclude:
-            resources:
-              namespaces:
-                - flux-system
-          match:
-            resources:
-              kinds:
-                - HelmRelease
-          name: helmReleaseSourceRefNamespace
-          preconditions:
-            any:
-              - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
-                operator: NotEquals
-                value: ""
-          validate:
-            deny:
-              conditions:
-                - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
-                  operator: NotEquals
-                  value: '{{request.object.metadata.namespace}}'
-            message: .spec.chart.spec.sourceRef.namespace must be the same as metadata.namespace
+      - exclude:
+          resources:
+            namespaces:
+            - flux-system
+        match:
+          resources:
+            kinds:
+            - Kustomization
+            - HelmRelease
+        name: serviceAccountName
+        validate:
+          message: .spec.serviceAccountName is required
+          pattern:
+            spec:
+              serviceAccountName: ?*
+      - exclude:
+          resources:
+            namespaces:
+            - flux-system
+        match:
+          resources:
+            kinds:
+            - Kustomization
+        name: kustomizationSourceRefNamespace
+        preconditions:
+          any:
+          - key: '{{request.object.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: ""
+        validate:
+          deny:
+            conditions:
+            - key: '{{request.object.spec.sourceRef.namespace}}'
+              operator: NotEquals
+              value: '{{request.object.metadata.namespace}}'
+          message: .spec.sourceRef.namespace must be the same as metadata.namespace
+      - exclude:
+          resources:
+            namespaces:
+            - flux-system
+        match:
+          resources:
+            kinds:
+            - HelmRelease
+        name: helmReleaseSourceRefNamespace
+        preconditions:
+          any:
+          - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+            operator: NotEquals
+            value: ""
+        validate:
+          deny:
+            conditions:
+            - key: '{{request.object.spec.chart.spec.sourceRef.namespace}}'
+              operator: NotEquals
+              value: '{{request.object.metadata.namespace}}'
+          message: .spec.chart.spec.sourceRef.namespace must be the same as metadata.namespace
       validationFailureAction: enforce

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: flux2-notification
 type: application
 version: 1.8.0
-appVersion: 0.41.1
+appVersion: 2.0.0-rc.3
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 0.41.1"
+    - "[Chore]: Update App Version to upstream 2.0.0-rc.3"

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.8.0
+version: 1.9.0
 appVersion: 2.0.0-rc.3
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-rc.3](https://img.shields.io/badge/AppVersion-2.0.0--rc.3-informational?style=flat-square)
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-rc.3](https://img.shields.io/badge/AppVersion-2.0.0--rc.3-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.41.1](https://img.shields.io/badge/AppVersion-0.41.1-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-rc.3](https://img.shields.io/badge/AppVersion-2.0.0--rc.3-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/templates/alert.yaml
+++ b/charts/flux2-notification/templates/alert.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.alertlist}}
 {{- range $key, $alert := .Values.alertlist }}
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Alert
 metadata:
   labels:

--- a/charts/flux2-notification/templates/provider.yaml
+++ b/charts/flux2-notification/templates/provider.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.providerlist}}
 {{- range $key, $provider := .Values.providerlist }}
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Provider
 metadata:
   labels:

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,16 +7,16 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         helm.sh/chart: flux2-notification-1.8.0
       name: all-kustomizations
       namespace: NAMESPACE
     spec:
       eventSeverity: error
       eventSources:
-      - kind: Kustomization
-        name: '*'
-        namespace: default
+        - kind: Kustomization
+          name: '*'
+          namespace: default
       providerRef:
         name: dev-msteams
       suspend: true

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -1,6 +1,6 @@
 should match snapshot:
   1: |
-    apiVersion: notification.toolkit.fluxcd.io/v1beta1
+    apiVersion: notification.toolkit.fluxcd.io/v1beta2
     kind: Alert
     metadata:
       labels:
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0-rc.3
-        helm.sh/chart: flux2-notification-1.8.0
+        helm.sh/chart: flux2-notification-1.9.0
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -14,9 +14,9 @@ should match snapshot:
     spec:
       eventSeverity: error
       eventSources:
-        - kind: Kustomization
-          name: '*'
-          namespace: default
+      - kind: Kustomization
+        name: '*'
+        namespace: default
       providerRef:
         name: dev-msteams
       suspend: true

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -1,6 +1,6 @@
 should match snapshot:
   1: |
-    apiVersion: notification.toolkit.fluxcd.io/v1beta1
+    apiVersion: notification.toolkit.fluxcd.io/v1beta2
     kind: Provider
     metadata:
       labels:
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0-rc.3
-        helm.sh/chart: flux2-notification-1.8.0
+        helm.sh/chart: flux2-notification-1.9.0
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         helm.sh/chart: flux2-notification-1.8.0
       name: on-call-slack
       namespace: NAMESPACE

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         helm.sh/chart: flux2-notification-1.8.0
       name: webhook-url
       namespace: NAMESPACE

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0-rc.3
-        helm.sh/chart: flux2-notification-1.8.0
+        helm.sh/chart: flux2-notification-1.9.0
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.4.0
-appVersion: 0.41.1
+version: 1.5.0
+appVersion: 2.0.0-rc.3
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 0.41.1"
+    - "[Chore]: Update App Version to upstream 2.0.0-rc.3"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.41.1](https://img.shields.io/badge/AppVersion-0.41.1-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-rc.3](https://img.shields.io/badge/AppVersion-2.0.0--rc.3-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v0.41.1"` |  |
+| cli.tag | string | `"v2.0.0-rc.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/templates/flux-gitrepository.yaml
+++ b/charts/flux2-sync/templates/flux-gitrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   labels:

--- a/charts/flux2-sync/templates/flux-kustomization.yaml
+++ b/charts/flux2-sync/templates/flux-kustomization.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kustomization }}
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   labels:

--- a/charts/flux2-sync/templates/flux-kustomization.yaml
+++ b/charts/flux2-sync/templates/flux-kustomization.yaml
@@ -68,7 +68,7 @@ spec:
 {{- if .Values.kustomizationlist}}
 {{- range $key, $kust := .Values.kustomizationlist }}
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   labels:

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -1,6 +1,6 @@
 should match snapshot of default values:
   1: |
-    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    apiVersion: source.toolkit.fluxcd.io/v1
     kind: GitRepository
     metadata:
       labels:
@@ -17,7 +17,7 @@ should match snapshot of default values:
       url: repository_url
 should match snapshot with special values:
   1: |
-    apiVersion: source.toolkit.fluxcd.io/v1beta2
+    apiVersion: source.toolkit.fluxcd.io/v1
     kind: GitRepository
     metadata:
       labels:

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.4.0
+        helm.sh/chart: flux2-sync-1.5.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.4.0
+        helm.sh/chart: flux2-sync-1.5.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.4.0
+        helm.sh/chart: flux2-sync-1.5.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -17,7 +17,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v0.41.1
+  tag: v2.0.0-rc.3
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 0.41.1"
+    - "[Chore]: Update App Version to upstream 2.0.0-rc.3"
 apiVersion: v2
-appVersion: 0.41.1
+appVersion: 2.0.0-rc.3
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.7.0
+version: 2.8.0

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.41.1](https://img.shields.io/badge/AppVersion-0.41.1-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-rc.3](https://img.shields.io/badge/AppVersion-2.0.0--rc.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v0.41.1"` |  |
+| cli.tag | string | `"v2.0.0-rc.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
@@ -39,7 +39,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmController.serviceAccount.annotations | object | `{}` |  |
 | helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
-| helmController.tag | string | `"v0.31.1"` |  |
+| helmController.tag | string | `"v0.33.0"` |  |
 | helmController.tolerations | list | `[]` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -57,7 +57,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
-| imageAutomationController.tag | string | `"v0.31.0"` |  |
+| imageAutomationController.tag | string | `"v0.33.1"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -76,7 +76,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v0.26.0"` |  |
+| imageReflectionController.tag | string | `"v0.27.2"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -100,7 +100,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v0.35.0"` |  |
+| kustomizeController.tag | string | `"v1.0.0-rc.3"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -124,7 +124,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationController.serviceAccount.annotations | object | `{}` |  |
 | notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
-| notificationController.tag | string | `"v0.33.0"` |  |
+| notificationController.tag | string | `"v1.0.0-rc.3"` |  |
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.service.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.service.labels | object | `{}` |  |
@@ -155,6 +155,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v0.36.0"` |  |
+| sourceController.tag | string | `"v1.0.0-rc.3"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | watchAllNamespaces | bool | `true` |  |

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -57,6 +57,27 @@ spec:
                 description: Chart defines the template of the v1beta2.HelmChart that
                   should be created for this HelmRelease.
                 properties:
+                  metadata:
+                    description: ObjectMeta holds the template for metadata like labels
+                      and annotations.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. More
+                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/'
+                        type: object
+                    type: object
                   spec:
                     description: Spec holds the template for the v1beta2.HelmChartSpec
                       for this HelmRelease.
@@ -307,6 +328,17 @@ spec:
                   this HelmRelease. Use '0' for an unlimited number of revisions;
                   defaults to '10'.
                 type: integer
+              persistentClient:
+                description: "PersistentClient tells the controller to use a persistent
+                  Kubernetes client for this release. When enabled, the client will
+                  be reused for the duration of the reconciliation, instead of being
+                  created and destroyed for each (step of a) Helm action. \n This
+                  can improve performance, but may cause issues with some Helm charts
+                  that for example do create Custom Resource Definitions during installation
+                  outside Helm's CRD lifecycle hooks, which are then not observed
+                  to be available by e.g. post-install hooks. \n If not set, it defaults
+                  to true."
+                type: boolean
               postRenderers:
                 description: PostRenderers holds an array of Helm PostRenderers, which
                   will be applied in order of their definition.
@@ -399,6 +431,8 @@ spec:
                                       selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                     type: string
                                 type: object
+                            required:
+                            - patch
                             type: object
                           type: array
                         patchesJson6902:

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -24,6 +24,488 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Kustomization is the Schema for the kustomizations API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KustomizationSpec defines the configuration to calculate
+              the desired state from a Source using Kustomize.
+            properties:
+              commonMetadata:
+                description: CommonMetadata specifies the common labels and annotations
+                  that are applied to all resources. Any existing label or annotation
+                  will be overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              components:
+                description: Components specifies relative paths to specifications
+                  of other Components.
+                items:
+                  type: string
+                type: array
+              decryption:
+                description: Decrypt Kubernetes secrets before applying them on the
+                  cluster.
+                properties:
+                  provider:
+                    description: Provider is the name of the decryption engine.
+                    enum:
+                    - sops
+                    type: string
+                  secretRef:
+                    description: The secret name containing the private OpenPGP keys
+                      used for decryption.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - provider
+                type: object
+              dependsOn:
+                description: DependsOn may contain a meta.NamespacedObjectReference
+                  slice with references to Kustomization resources that must be ready
+                  before this Kustomization can be reconciled.
+                items:
+                  description: NamespacedObjectReference contains enough information
+                    to locate the referenced Kubernetes resource object in any namespace.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              force:
+                default: false
+                description: Force instructs the controller to recreate resources
+                  when patching fails due to an immutable field change.
+                type: boolean
+              healthChecks:
+                description: A list of resources to be included in the health assessment.
+                items:
+                  description: NamespacedObjectKindReference contains enough information
+                    to locate the typed referenced Kubernetes resource object in any
+                    namespace.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent, if not specified the
+                        Kubernetes preferred version will be used.
+                      type: string
+                    kind:
+                      description: Kind of the referent.
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it
+                        acts as LocalObjectReference.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              images:
+                description: Images is a list of (image name, new name, new tag or
+                  digest) for changing image names, tags or digests. This can also
+                  be achieved with a patch, but this operator is simpler to specify.
+                items:
+                  description: Image contains an image name, a new name, a new tag
+                    or digest, which will replace the original name and tag.
+                  properties:
+                    digest:
+                      description: Digest is the value used to replace the original
+                        image tag. If digest is present NewTag value is ignored.
+                      type: string
+                    name:
+                      description: Name is a tag-less image name.
+                      type: string
+                    newName:
+                      description: NewName is the value used to replace the original
+                        name.
+                      type: string
+                    newTag:
+                      description: NewTag is the value used to replace the original
+                        tag.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              interval:
+                description: The interval at which to reconcile the Kustomization.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              kubeConfig:
+                description: The KubeConfig for reconciling the Kustomization on a
+                  remote cluster. When used in combination with KustomizationSpec.ServiceAccountName,
+                  forces the controller to act on behalf of that Service Account at
+                  the target cluster. If the --default-service-account flag is set,
+                  its value will be used as a controller level fallback for when KustomizationSpec.ServiceAccountName
+                  is empty.
+                properties:
+                  secretRef:
+                    description: SecretRef holds the name of a secret that contains
+                      a key with the kubeconfig file as the value. If no key is set,
+                      the key will default to 'value'. It is recommended that the
+                      kubeconfig is self-contained, and the secret is regularly updated
+                      if credentials such as a cloud-access-token expire. Cloud specific
+                      `cmd-path` auth helpers will not function without adding binaries
+                      and credentials to the Pod that is responsible for reconciling
+                      Kubernetes resources.
+                    properties:
+                      key:
+                        description: Key in the Secret, when not specified an implementation-specific
+                          default key is used.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - secretRef
+                type: object
+              patches:
+                description: Strategic merge and JSON patches, defined as inline YAML
+                  objects, capable of targeting objects based on kind, label and annotation
+                  selectors.
+                items:
+                  description: Patch contains an inline StrategicMerge or JSON6902
+                    patch, and the target the patch should be applied to.
+                  properties:
+                    patch:
+                      description: Patch contains an inline StrategicMerge patch or
+                        an inline JSON6902 patch with an array of operation objects.
+                      type: string
+                    target:
+                      description: Target points to the resources that the patch document
+                        should be applied to.
+                      properties:
+                        annotationSelector:
+                          description: AnnotationSelector is a string that follows
+                            the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: Group is the API group to select resources
+                            from. Together with Version and Kind it is capable of
+                            unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: LabelSelector is a string that follows the
+                            label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: Version of the API Group to select resources
+                            from. Together with Group and Kind it is capable of unambiguously
+                            identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
+                  required:
+                  - patch
+                  type: object
+                type: array
+              path:
+                description: Path to the directory containing the kustomization.yaml
+                  file, or the set of plain YAMLs a kustomization.yaml should be generated
+                  for. Defaults to 'None', which translates to the root path of the
+                  SourceRef.
+                type: string
+              postBuild:
+                description: PostBuild describes which actions to perform on the YAML
+                  manifest generated by building the kustomize overlay.
+                properties:
+                  substitute:
+                    additionalProperties:
+                      type: string
+                    description: Substitute holds a map of key/value pairs. The variables
+                      defined in your YAML manifests that match any of the keys defined
+                      in the map will be substituted with the set value. Includes
+                      support for bash string replacement functions e.g. ${var:=default},
+                      ${var:position} and ${var/substring/replacement}.
+                    type: object
+                  substituteFrom:
+                    description: SubstituteFrom holds references to ConfigMaps and
+                      Secrets containing the variables and their values to be substituted
+                      in the YAML manifests. The ConfigMap and the Secret data keys
+                      represent the var names, and they must match the vars declared
+                      in the manifests for the substitution to happen.
+                    items:
+                      description: SubstituteReference contains a reference to a resource
+                        containing the variables name and value.
+                      properties:
+                        kind:
+                          description: Kind of the values referent, valid values are
+                            ('Secret', 'ConfigMap').
+                          enum:
+                          - Secret
+                          - ConfigMap
+                          type: string
+                        name:
+                          description: Name of the values referent. Should reside
+                            in the same namespace as the referring resource.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        optional:
+                          default: false
+                          description: Optional indicates whether the referenced resource
+                            must exist, or whether to tolerate its absence. If true
+                            and the referenced resource is absent, proceed as if the
+                            resource was present but empty, without any variables
+                            defined.
+                          type: boolean
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                type: object
+              prune:
+                description: Prune enables garbage collection.
+                type: boolean
+              retryInterval:
+                description: The interval at which to retry a previously failed reconciliation.
+                  When not specified, the controller uses the KustomizationSpec.Interval
+                  value to retry failures.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              serviceAccountName:
+                description: The name of the Kubernetes service account to impersonate
+                  when reconciling this Kustomization.
+                type: string
+              sourceRef:
+                description: Reference of the source where the kustomization file
+                  is.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    enum:
+                    - OCIRepository
+                    - GitRepository
+                    - Bucket
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                  namespace:
+                    description: Namespace of the referent, defaults to the namespace
+                      of the Kubernetes resource object that contains the reference.
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              suspend:
+                description: This flag tells the controller to suspend subsequent
+                  kustomize executions, it does not apply to already started executions.
+                  Defaults to false.
+                type: boolean
+              targetNamespace:
+                description: TargetNamespace sets or overrides the namespace in the
+                  kustomization.yaml file.
+                maxLength: 63
+                minLength: 1
+                type: string
+              timeout:
+                description: Timeout for validation, apply and health checking operations.
+                  Defaults to 'Interval' duration.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              wait:
+                description: Wait instructs the controller to check the health of
+                  all the reconciled resources. When enabled, the HealthChecks are
+                  ignored. Defaults to false.
+                type: boolean
+            required:
+            - interval
+            - prune
+            - sourceRef
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: KustomizationStatus defines the observed state of a kustomization.
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              inventory:
+                description: Inventory contains the list of Kubernetes resource object
+                  references that have been successfully applied.
+                properties:
+                  entries:
+                    description: Entries of Kubernetes resource object references.
+                    items:
+                      description: ResourceRef contains the information necessary
+                        to locate a resource within a cluster.
+                      properties:
+                        id:
+                          description: ID is the string representation of the Kubernetes
+                            resource object's metadata, in the format '<namespace>_<name>_<group>_<kind>'.
+                          type: string
+                        v:
+                          description: Version is the API version of the Kubernetes
+                            resource object's kind.
+                          type: string
+                      required:
+                      - id
+                      - v
+                      type: object
+                    type: array
+                required:
+                - entries
+                type: object
+              lastAppliedRevision:
+                description: The last successfully applied revision. Equals the Revision
+                  of the applied Artifact from the referenced Source.
+                type: string
+              lastAttemptedRevision:
+                description: LastAttemptedRevision is the revision of the last reconciliation
+                  attempt.
+                type: string
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last reconciled generation.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -33,6 +515,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: v1beta1 Kustomization is deprecated, upgrade to v1
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -226,6 +710,8 @@ spec:
                             identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                           type: string
                       type: object
+                  required:
+                  - patch
                   type: object
                 type: array
               patchesJson6902:
@@ -570,6 +1056,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
+    deprecated: true
+    deprecationWarning: v1beta2 Kustomization is deprecated, upgrade to v1
     name: v1beta2
     schema:
       openAPIV3Schema:
@@ -591,9 +1079,25 @@ spec:
             description: KustomizationSpec defines the configuration to calculate
               the desired state from a Source using Kustomize.
             properties:
+              commonMetadata:
+                description: CommonMetadata specifies the common labels and annotations
+                  that are applied to all resources. Any existing label or annotation
+                  will be overridden if its key matches a common one.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
               components:
                 description: Components specifies relative paths to specifications
-                  of other Components
+                  of other Components.
                 items:
                   type: string
                 type: array
@@ -780,6 +1284,8 @@ spec:
                             identifying and/or selecting resources. https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                           type: string
                       type: object
+                  required:
+                  - patch
                   type: object
                 type: array
               patchesJson6902:
@@ -1123,7 +1629,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 {{- end }}

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -246,6 +246,14 @@ spec:
             description: AlertSpec defines an alerting rule for events involving a
               list of objects.
             properties:
+              eventMetadata:
+                additionalProperties:
+                  type: string
+                description: EventMetadata is an optional field for adding metadata
+                  to events emitted by the controller. Metadata fields added by the
+                  controller have priority over the fields added here, and the fields
+                  added here have priority over fields originally present in the event.
+                type: object
               eventSeverity:
                 default: info
                 description: EventSeverity specifies how to filter events based on
@@ -262,10 +270,10 @@ spec:
                     to let you locate the typed referenced object at cluster level
                   properties:
                     apiVersion:
-                      description: API version of the referent.
+                      description: API version of the referent
                       type: string
                     kind:
-                      description: Kind of the referent.
+                      description: Kind of the referent
                       enum:
                       - Bucket
                       - GitRepository
@@ -285,25 +293,33 @@ spec:
                         {key,value} in the matchLabels map is equivalent to an element
                         of matchExpressions, whose key field is "key", the operator
                         is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                        are ANDed. MatchLabels requires the name to be set to `*`.
                       type: object
                     name:
-                      description: Name of the referent.
+                      description: Name of the referent If multiple resources are
+                        targeted `*` may be set.
                       maxLength: 53
                       minLength: 1
                       type: string
                     namespace:
-                      description: Namespace of the referent.
+                      description: Namespace of the referent
                       maxLength: 53
                       minLength: 1
                       type: string
                   required:
+                  - kind
                   - name
                   type: object
                 type: array
               exclusionList:
                 description: ExclusionList specifies a list of Golang regular expressions
                   to be used for excluding messages.
+                items:
+                  type: string
+                type: array
+              inclusionList:
+                description: InclusionList specifies a list of Golang regular expressions
+                  to be used for including messages.
                 items:
                   type: string
                 type: array
@@ -859,6 +875,227 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Receiver is the Schema for the receivers API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReceiverSpec defines the desired state of the Receiver.
+            properties:
+              events:
+                description: Events specifies the list of event types to handle, e.g.
+                  'push' for GitHub or 'Push Hook' for GitLab.
+                items:
+                  type: string
+                type: array
+              interval:
+                default: 10m
+                description: Interval at which to reconcile the Receiver with its
+                  Secret references.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              resources:
+                description: A list of resources to be notified about changes.
+                items:
+                  description: CrossNamespaceObjectReference contains enough information
+                    to let you locate the typed referenced object at cluster level
+                  properties:
+                    apiVersion:
+                      description: API version of the referent
+                      type: string
+                    kind:
+                      description: Kind of the referent
+                      enum:
+                      - Bucket
+                      - GitRepository
+                      - Kustomization
+                      - HelmRelease
+                      - HelmChart
+                      - HelmRepository
+                      - ImageRepository
+                      - ImagePolicy
+                      - ImageUpdateAutomation
+                      - OCIRepository
+                      type: string
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: MatchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed. MatchLabels requires the name to be set to `*`.
+                      type: object
+                    name:
+                      description: Name of the referent If multiple resources are
+                        targeted `*` may be set.
+                      maxLength: 53
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: Namespace of the referent
+                      maxLength: 53
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              secretRef:
+                description: SecretRef specifies the Secret containing the token used
+                  to validate the payload authenticity.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: Suspend tells the controller to suspend subsequent events
+                  handling for this receiver.
+                type: boolean
+              type:
+                description: Type of webhook sender, used to determine the validation
+                  procedure and payload deserialization.
+                enum:
+                - generic
+                - generic-hmac
+                - github
+                - gitlab
+                - bitbucket
+                - harbor
+                - dockerhub
+                - quay
+                - gcr
+                - nexus
+                - acr
+                type: string
+            required:
+            - resources
+            - secretRef
+            - type
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: ReceiverStatus defines the observed state of the Receiver.
+            properties:
+              conditions:
+                description: Conditions holds the conditions for the Receiver.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the Receiver object.
+                format: int64
+                type: integer
+              webhookPath:
+                description: WebhookPath is the generated incoming webhook address
+                  in the format of '/hook/sha256sum(token+name+namespace)'.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta1 Receiver is deprecated, upgrade to v1
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -1061,6 +1298,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
+    deprecated: true
+    deprecationWarning: v1beta2 Receiver is deprecated, upgrade to v1
     name: v1beta2
     schema:
       openAPIV3Schema:
@@ -1099,10 +1338,10 @@ spec:
                     to let you locate the typed referenced object at cluster level
                   properties:
                     apiVersion:
-                      description: API version of the referent.
+                      description: API version of the referent
                       type: string
                     kind:
-                      description: Kind of the referent.
+                      description: Kind of the referent
                       enum:
                       - Bucket
                       - GitRepository
@@ -1122,19 +1361,21 @@ spec:
                         {key,value} in the matchLabels map is equivalent to an element
                         of matchExpressions, whose key field is "key", the operator
                         is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                        are ANDed. MatchLabels requires the name to be set to `*`.
                       type: object
                     name:
-                      description: Name of the referent.
+                      description: Name of the referent If multiple resources are
+                        targeted `*` may be set.
                       maxLength: 53
                       minLength: 1
                       type: string
                     namespace:
-                      description: Namespace of the referent.
+                      description: Namespace of the referent
                       maxLength: 53
                       minLength: 1
                       type: string
                   required:
+                  - kind
                   - name
                   type: object
                 type: array
@@ -1268,7 +1509,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 {{- end }}

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -382,10 +382,6 @@ spec:
               artifact:
                 description: Artifact represents the last successful Bucket reconciliation.
                 properties:
-                  checksum:
-                    description: 'Checksum is the SHA256 checksum of the Artifact
-                      file. Deprecated: use Artifact.Digest instead.'
-                    type: string
                   digest:
                     description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
                     pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
@@ -421,7 +417,9 @@ spec:
                       the Artifact contents.
                     type: string
                 required:
+                - lastUpdateTime
                 - path
+                - revision
                 - url
                 type: object
               conditions:
@@ -547,6 +545,391 @@ spec:
     - jsonPath: .spec.url
       name: URL
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: GitRepository is the Schema for the gitrepositories API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitRepositorySpec specifies the required configuration to
+              produce an Artifact for a Git repository.
+            properties:
+              ignore:
+                description: Ignore overrides the set of excluded patterns in the
+                  .sourceignore format (which is the same as .gitignore). If not provided,
+                  a default will be used, consult the documentation for your version
+                  to find out what those are.
+                type: string
+              include:
+                description: Include specifies a list of GitRepository resources which
+                  Artifacts should be included in the Artifact produced for this GitRepository.
+                items:
+                  description: GitRepositoryInclude specifies a local reference to
+                    a GitRepository which Artifact (sub-)contents must be included,
+                    and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: FromPath specifies the path to copy contents from,
+                        defaults to the root of the Artifact.
+                      type: string
+                    repository:
+                      description: GitRepositoryRef specifies the GitRepository which
+                        Artifact contents must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: ToPath specifies the path to copy contents to,
+                        defaults to the name of the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              interval:
+                description: Interval at which to check the GitRepository for updates.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              recurseSubmodules:
+                description: RecurseSubmodules enables the initialization of all submodules
+                  within the GitRepository as cloned from the URL, using their default
+                  settings.
+                type: boolean
+              ref:
+                description: Reference specifies the Git reference to resolve and
+                  monitor for changes, defaults to the 'master' branch.
+                properties:
+                  branch:
+                    description: Branch to check out, defaults to 'master' if no other
+                      field is defined.
+                    type: string
+                  commit:
+                    description: "Commit SHA to check out, takes precedence over all
+                      reference fields. \n This can be combined with Branch to shallow
+                      clone the branch, in which the commit is expected to exist."
+                    type: string
+                  name:
+                    description: "Name of the reference to check out; takes precedence
+                      over Branch, Tag and SemVer. \n It must be a valid Git reference:
+                      https://git-scm.com/docs/git-check-ref-format#_description Examples:
+                      \"refs/heads/main\", \"refs/tags/v0.1.0\", \"refs/pull/420/head\",
+                      \"refs/merge-requests/1/head\""
+                    type: string
+                  semver:
+                    description: SemVer tag expression to check out, takes precedence
+                      over Tag.
+                    type: string
+                  tag:
+                    description: Tag to check out, takes precedence over Branch.
+                    type: string
+                type: object
+              secretRef:
+                description: SecretRef specifies the Secret containing authentication
+                  credentials for the GitRepository. For HTTPS repositories the Secret
+                  must contain 'username' and 'password' fields for basic auth or
+                  'bearerToken' field for token auth. For SSH repositories the Secret
+                  must contain 'identity' and 'known_hosts' fields.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              suspend:
+                description: Suspend tells the controller to suspend the reconciliation
+                  of this GitRepository.
+                type: boolean
+              timeout:
+                default: 60s
+                description: Timeout for Git operations like cloning, defaults to
+                  60s.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                type: string
+              url:
+                description: URL specifies the Git repository URL, it can be an HTTP/S
+                  or SSH address.
+                pattern: ^(http|https|ssh)://.*$
+                type: string
+              verify:
+                description: Verification specifies the configuration to verify the
+                  Git commit signature(s).
+                properties:
+                  mode:
+                    description: Mode specifies what Git object should be verified,
+                      currently ('head').
+                    enum:
+                    - head
+                    type: string
+                  secretRef:
+                    description: SecretRef specifies the Secret containing the public
+                      keys of trusted Git authors.
+                    properties:
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - mode
+                - secretRef
+                type: object
+            required:
+            - interval
+            - url
+            type: object
+          status:
+            default:
+              observedGeneration: -1
+            description: GitRepositoryStatus records the observed state of a Git repository.
+            properties:
+              artifact:
+                description: Artifact represents the last successful GitRepository
+                  reconciliation.
+                properties:
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is the timestamp corresponding to
+                      the last update of the Artifact.
+                    format: date-time
+                    type: string
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    description: Metadata holds upstream information such as OCI annotations.
+                    type: object
+                  path:
+                    description: Path is the relative file path of the Artifact. It
+                      can be used to locate the file in the root of the Artifact storage
+                      on the local file system of the controller managing the Source.
+                    type: string
+                  revision:
+                    description: Revision is a human-readable identifier traceable
+                      in the origin source system. It can be a Git commit SHA, Git
+                      tag, a Helm chart version, etc.
+                    type: string
+                  size:
+                    description: Size is the number of bytes in the file.
+                    format: int64
+                    type: integer
+                  url:
+                    description: URL is the HTTP address of the Artifact as exposed
+                      by the controller managing the Source. It can be used to retrieve
+                      the Artifact for consumption, e.g. by another controller applying
+                      the Artifact contents.
+                    type: string
+                required:
+                - lastUpdateTime
+                - path
+                - revision
+                - url
+                type: object
+              conditions:
+                description: Conditions holds the conditions for the GitRepository.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              includedArtifacts:
+                description: IncludedArtifacts contains a list of the last successfully
+                  included Artifacts as instructed by GitRepositorySpec.Include.
+                items:
+                  description: Artifact represents the output of a Source reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of
+                        '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: LastUpdateTime is the timestamp corresponding to
+                        the last update of the Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI
+                        annotations.
+                      type: object
+                    path:
+                      description: Path is the relative file path of the Artifact.
+                        It can be used to locate the file in the root of the Artifact
+                        storage on the local file system of the controller managing
+                        the Source.
+                      type: string
+                    revision:
+                      description: Revision is a human-readable identifier traceable
+                        in the origin source system. It can be a Git commit SHA, Git
+                        tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: URL is the HTTP address of the Artifact as exposed
+                        by the controller managing the Source. It can be used to retrieve
+                        the Artifact for consumption, e.g. by another controller applying
+                        the Artifact contents.
+                      type: string
+                  required:
+                  - lastUpdateTime
+                  - path
+                  - revision
+                  - url
+                  type: object
+                type: array
+              lastHandledReconcileAt:
+                description: LastHandledReconcileAt holds the value of the most recent
+                  reconcile request value, so a change of the annotation value can
+                  be detected.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the last observed generation of
+                  the GitRepository object.
+                format: int64
+                type: integer
+              observedIgnore:
+                description: ObservedIgnore is the observed exclusion patterns used
+                  for constructing the source artifact.
+                type: string
+              observedInclude:
+                description: ObservedInclude is the observed list of GitRepository
+                  resources used to produce the current Artifact.
+                items:
+                  description: GitRepositoryInclude specifies a local reference to
+                    a GitRepository which Artifact (sub-)contents must be included,
+                    and where they should be placed.
+                  properties:
+                    fromPath:
+                      description: FromPath specifies the path to copy contents from,
+                        defaults to the root of the Artifact.
+                      type: string
+                    repository:
+                      description: GitRepositoryRef specifies the GitRepository which
+                        Artifact contents must be included.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    toPath:
+                      description: ToPath specifies the path to copy contents to,
+                        defaults to the name of the GitRepositoryRef.
+                      type: string
+                  required:
+                  - repository
+                  type: object
+                type: array
+              observedRecurseSubmodules:
+                description: ObservedRecurseSubmodules is the observed resource submodules
+                  configuration used to produce the current Artifact.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -556,6 +939,8 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: v1beta1 GitRepository is deprecated, upgrade to v1
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -886,6 +1271,8 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Ready")].message
       name: Status
       type: string
+    deprecated: true
+    deprecationWarning: v1beta2 GitRepository is deprecated, upgrade to v1
     name: v1beta2
     schema:
       openAPIV3Schema:
@@ -1068,6 +1455,7 @@ spec:
                     type: object
                 required:
                 - mode
+                - secretRef
                 type: object
             required:
             - interval
@@ -1082,10 +1470,6 @@ spec:
                 description: Artifact represents the last successful GitRepository
                   reconciliation.
                 properties:
-                  checksum:
-                    description: 'Checksum is the SHA256 checksum of the Artifact
-                      file. Deprecated: use Artifact.Digest instead.'
-                    type: string
                   digest:
                     description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
                     pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
@@ -1121,7 +1505,9 @@ spec:
                       the Artifact contents.
                     type: string
                 required:
+                - lastUpdateTime
                 - path
+                - revision
                 - url
                 type: object
               conditions:
@@ -1209,10 +1595,6 @@ spec:
                 items:
                   description: Artifact represents the output of a Source reconciliation.
                   properties:
-                    checksum:
-                      description: 'Checksum is the SHA256 checksum of the Artifact
-                        file. Deprecated: use Artifact.Digest instead.'
-                      type: string
                     digest:
                       description: Digest is the digest of the file in the form of
                         '<algorithm>:<checksum>'.
@@ -1251,7 +1633,9 @@ spec:
                         the Artifact contents.
                       type: string
                   required:
+                  - lastUpdateTime
                   - path
+                  - revision
                   - url
                   type: object
                 type: array
@@ -1311,7 +1695,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 ---
@@ -1773,10 +2157,6 @@ spec:
                 description: Artifact represents the output of the last successful
                   reconciliation.
                 properties:
-                  checksum:
-                    description: 'Checksum is the SHA256 checksum of the Artifact
-                      file. Deprecated: use Artifact.Digest instead.'
-                    type: string
                   digest:
                     description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
                     pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
@@ -1812,7 +2192,9 @@ spec:
                       the Artifact contents.
                     type: string
                 required:
+                - lastUpdateTime
                 - path
+                - revision
                 - url
                 type: object
               conditions:
@@ -2289,10 +2671,6 @@ spec:
                 description: Artifact represents the last successful HelmRepository
                   reconciliation.
                 properties:
-                  checksum:
-                    description: 'Checksum is the SHA256 checksum of the Artifact
-                      file. Deprecated: use Artifact.Digest instead.'
-                    type: string
                   digest:
                     description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
                     pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
@@ -2328,7 +2706,9 @@ spec:
                       the Artifact contents.
                     type: string
                 required:
+                - lastUpdateTime
                 - path
+                - revision
                 - url
                 type: object
               conditions:
@@ -2623,10 +3003,6 @@ spec:
                 description: Artifact represents the output of the last successful
                   OCI Repository sync.
                 properties:
-                  checksum:
-                    description: 'Checksum is the SHA256 checksum of the Artifact
-                      file. Deprecated: use Artifact.Digest instead.'
-                    type: string
                   digest:
                     description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
                     pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
@@ -2662,7 +3038,9 @@ spec:
                       the Artifact contents.
                     type: string
                 required:
+                - lastUpdateTime
                 - path
+                - revision
                 - url
                 type: object
               conditions:

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         control-plane: controller
-        helm.sh/chart: flux2-2.7.0
+        helm.sh/chart: flux2-2.8.0
       name: helm-controller
     spec:
       replicas: 1
@@ -28,53 +28,53 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-          - args:
-            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-            - --watch-all-namespaces=true
-            - --log-level=info
-            - --log-encoding=json
-            - --enable-leader-election
-            env:
-            - name: RUNTIME_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/helm-controller:v0.31.1
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /healthz
-                port: healthz
-            name: manager
-            ports:
-            - containerPort: 8080
-              name: http-prom
-            - containerPort: 9440
-              name: healthz
-              protocol: TCP
-            readinessProbe:
-              httpGet:
-                path: /readyz
-                port: healthz
-            resources:
-              limits: {}
-              requests:
-                cpu: 100m
-                memory: 64Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
-            volumeMounts:
-            - mountPath: /tmp
-              name: temp
+            - args:
+                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+                - --watch-all-namespaces=true
+                - --log-level=info
+                - --log-encoding=json
+                - --enable-leader-election
+              env:
+                - name: RUNTIME_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: ghcr.io/fluxcd/helm-controller:v0.33.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: healthz
+              name: manager
+              ports:
+                - containerPort: 8080
+                  name: http-prom
+                - containerPort: 9440
+                  name: healthz
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: healthz
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - mountPath: /tmp
+                  name: temp
           serviceAccountName: helm-controller
           terminationGracePeriodSeconds: 600
           volumes:
-          - emptyDir: {}
-            name: temp
+            - emptyDir: {}
+              name: temp

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -28,53 +28,53 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-            - args:
-                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-                - --watch-all-namespaces=true
-                - --log-level=info
-                - --log-encoding=json
-                - --enable-leader-election
-              env:
-                - name: RUNTIME_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/helm-controller:v0.33.0
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: healthz
-              name: manager
-              ports:
-                - containerPort: 8080
-                  name: http-prom
-                - containerPort: 9440
-                  name: healthz
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: healthz
-              resources:
-                limits: {}
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
-              volumeMounts:
-                - mountPath: /tmp
-                  name: temp
+          - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/helm-controller:v0.33.0
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits: {}
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
           serviceAccountName: helm-controller
           terminationGracePeriodSeconds: 600
           volumes:
-            - emptyDir: {}
-              name: temp
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -26,55 +26,55 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-            - args:
-                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-                - --watch-all-namespaces=true
-                - --log-level=info
-                - --log-encoding=json
-                - --enable-leader-election
-              env:
-                - name: RUNTIME_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-automation-controller:v0.33.1
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: healthz
-              name: manager
-              ports:
-                - containerPort: 8080
-                  name: http-prom
-                - containerPort: 9440
-                  name: healthz
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: healthz
-              resources:
-                limits: {}
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
-              volumeMounts:
-                - mountPath: /tmp
-                  name: temp
+          - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/image-automation-controller:v0.33.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits: {}
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
           securityContext:
             fsGroup: 1337
           serviceAccountName: image-automation-controller
           terminationGracePeriodSeconds: 10
           volumes:
-            - emptyDir: {}
-              name: temp
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         control-plane: controller
-        helm.sh/chart: flux2-2.7.0
+        helm.sh/chart: flux2-2.8.0
       name: image-automation-controller
     spec:
       replicas: 1
@@ -26,55 +26,55 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-          - args:
-            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-            - --watch-all-namespaces=true
-            - --log-level=info
-            - --log-encoding=json
-            - --enable-leader-election
-            env:
-            - name: RUNTIME_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/image-automation-controller:v0.31.0
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /healthz
-                port: healthz
-            name: manager
-            ports:
-            - containerPort: 8080
-              name: http-prom
-            - containerPort: 9440
-              name: healthz
-              protocol: TCP
-            readinessProbe:
-              httpGet:
-                path: /readyz
-                port: healthz
-            resources:
-              limits: {}
-              requests:
-                cpu: 100m
-                memory: 64Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
-            volumeMounts:
-            - mountPath: /tmp
-              name: temp
+            - args:
+                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+                - --watch-all-namespaces=true
+                - --log-level=info
+                - --log-encoding=json
+                - --enable-leader-election
+              env:
+                - name: RUNTIME_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: ghcr.io/fluxcd/image-automation-controller:v0.33.1
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: healthz
+              name: manager
+              ports:
+                - containerPort: 8080
+                  name: http-prom
+                - containerPort: 9440
+                  name: healthz
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: healthz
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - mountPath: /tmp
+                  name: temp
           securityContext:
             fsGroup: 1337
           serviceAccountName: image-automation-controller
           terminationGracePeriodSeconds: 10
           volumes:
-          - emptyDir: {}
-            name: temp
+            - emptyDir: {}
+              name: temp

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -26,59 +26,59 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-            - args:
-                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-                - --watch-all-namespaces=true
-                - --log-level=info
-                - --log-encoding=json
-                - --enable-leader-election
-              env:
-                - name: RUNTIME_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-reflector-controller:v0.27.2
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: healthz
-              name: manager
-              ports:
-                - containerPort: 8080
-                  name: http-prom
-                - containerPort: 9440
-                  name: healthz
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: healthz
-              resources:
-                limits: {}
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
-              volumeMounts:
-                - mountPath: /tmp
-                  name: temp
-                - mountPath: /data
-                  name: data
+          - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/image-reflector-controller:v0.27.2
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits: {}
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
+            - mountPath: /data
+              name: data
           securityContext:
             fsGroup: 1337
           serviceAccountName: image-reflector-controller
           terminationGracePeriodSeconds: 10
           volumes:
-            - emptyDir: {}
-              name: temp
-            - emptyDir: {}
-              name: data
+          - emptyDir: {}
+            name: temp
+          - emptyDir: {}
+            name: data

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         control-plane: controller
-        helm.sh/chart: flux2-2.7.0
+        helm.sh/chart: flux2-2.8.0
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -26,59 +26,59 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-          - args:
-            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-            - --watch-all-namespaces=true
-            - --log-level=info
-            - --log-encoding=json
-            - --enable-leader-election
-            env:
-            - name: RUNTIME_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/image-reflector-controller:v0.26.0
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /healthz
-                port: healthz
-            name: manager
-            ports:
-            - containerPort: 8080
-              name: http-prom
-            - containerPort: 9440
-              name: healthz
-              protocol: TCP
-            readinessProbe:
-              httpGet:
-                path: /readyz
-                port: healthz
-            resources:
-              limits: {}
-              requests:
-                cpu: 100m
-                memory: 64Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
-            volumeMounts:
-            - mountPath: /tmp
-              name: temp
-            - mountPath: /data
-              name: data
+            - args:
+                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+                - --watch-all-namespaces=true
+                - --log-level=info
+                - --log-encoding=json
+                - --enable-leader-election
+              env:
+                - name: RUNTIME_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: ghcr.io/fluxcd/image-reflector-controller:v0.27.2
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: healthz
+              name: manager
+              ports:
+                - containerPort: 8080
+                  name: http-prom
+                - containerPort: 9440
+                  name: healthz
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: healthz
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - mountPath: /tmp
+                  name: temp
+                - mountPath: /data
+                  name: data
           securityContext:
             fsGroup: 1337
           serviceAccountName: image-reflector-controller
           terminationGracePeriodSeconds: 10
           volumes:
-          - emptyDir: {}
-            name: temp
-          - emptyDir: {}
-            name: data
+            - emptyDir: {}
+              name: temp
+            - emptyDir: {}
+              name: data

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
-        helm.sh/chart: flux2-2.7.0
+        app.kubernetes.io/version: 2.0.0-rc.3
+        helm.sh/chart: flux2-2.8.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -26,55 +26,55 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-            - args:
-                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-                - --watch-all-namespaces=true
-                - --log-level=info
-                - --log-encoding=json
-                - --enable-leader-election
-              env:
-                - name: RUNTIME_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/kustomize-controller:v1.0.0-rc.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: healthz
-              name: manager
-              ports:
-                - containerPort: 8080
-                  name: http-prom
-                - containerPort: 9440
-                  name: healthz
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: healthz
-              resources:
-                limits: {}
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
-              volumeMounts:
-                - mountPath: /tmp
-                  name: temp
+          - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/kustomize-controller:v1.0.0-rc.3
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 8080
+              name: http-prom
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits: {}
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
           securityContext:
             fsGroup: 1337
           serviceAccountName: kustomize-controller
           terminationGracePeriodSeconds: 60
           volumes:
-            - emptyDir: {}
-              name: temp
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         control-plane: controller
-        helm.sh/chart: flux2-2.7.0
+        helm.sh/chart: flux2-2.8.0
       name: kustomize-controller
     spec:
       replicas: 1
@@ -26,55 +26,55 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-          - args:
-            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-            - --watch-all-namespaces=true
-            - --log-level=info
-            - --log-encoding=json
-            - --enable-leader-election
-            env:
-            - name: RUNTIME_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/kustomize-controller:v0.35.0
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /healthz
-                port: healthz
-            name: manager
-            ports:
-            - containerPort: 8080
-              name: http-prom
-            - containerPort: 9440
-              name: healthz
-              protocol: TCP
-            readinessProbe:
-              httpGet:
-                path: /readyz
-                port: healthz
-            resources:
-              limits: {}
-              requests:
-                cpu: 100m
-                memory: 64Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
-            volumeMounts:
-            - mountPath: /tmp
-              name: temp
+            - args:
+                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+                - --watch-all-namespaces=true
+                - --log-level=info
+                - --log-encoding=json
+                - --enable-leader-election
+              env:
+                - name: RUNTIME_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: ghcr.io/fluxcd/kustomize-controller:v1.0.0-rc.3
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: healthz
+              name: manager
+              ports:
+                - containerPort: 8080
+                  name: http-prom
+                - containerPort: 9440
+                  name: healthz
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: healthz
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - mountPath: /tmp
+                  name: temp
           securityContext:
             fsGroup: 1337
           serviceAccountName: kustomize-controller
           terminationGracePeriodSeconds: 60
           volumes:
-          - emptyDir: {}
-            name: temp
+            - emptyDir: {}
+              name: temp

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         control-plane: controller
-        helm.sh/chart: flux2-2.7.0
+        helm.sh/chart: flux2-2.8.0
       name: notification-controller
     spec:
       replicas: 1
@@ -26,59 +26,59 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-          - args:
-            - --watch-all-namespaces=true
-            - --log-level=info
-            - --log-encoding=json
-            - --enable-leader-election
-            env:
-            - name: RUNTIME_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/notification-controller:v0.33.0
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /healthz
-                port: healthz
-            name: manager
-            ports:
-            - containerPort: 9090
-              name: http
-              protocol: TCP
-            - containerPort: 9292
-              name: http-webhook
-              protocol: TCP
-            - containerPort: 8080
-              name: http-prom
-              protocol: TCP
-            - containerPort: 9440
-              name: healthz
-              protocol: TCP
-            readinessProbe:
-              httpGet:
-                path: /readyz
-                port: healthz
-            resources:
-              limits: {}
-              requests:
-                cpu: 100m
-                memory: 64Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
-            volumeMounts:
-            - mountPath: /tmp
-              name: temp
+            - args:
+                - --watch-all-namespaces=true
+                - --log-level=info
+                - --log-encoding=json
+                - --enable-leader-election
+              env:
+                - name: RUNTIME_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: ghcr.io/fluxcd/notification-controller:v1.0.0-rc.3
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: healthz
+              name: manager
+              ports:
+                - containerPort: 9090
+                  name: http
+                  protocol: TCP
+                - containerPort: 9292
+                  name: http-webhook
+                  protocol: TCP
+                - containerPort: 8080
+                  name: http-prom
+                  protocol: TCP
+                - containerPort: 9440
+                  name: healthz
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: healthz
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - mountPath: /tmp
+                  name: temp
           serviceAccountName: notification-controller
           terminationGracePeriodSeconds: 10
           volumes:
-          - emptyDir: {}
-            name: temp
+            - emptyDir: {}
+              name: temp

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -26,59 +26,59 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-            - args:
-                - --watch-all-namespaces=true
-                - --log-level=info
-                - --log-encoding=json
-                - --enable-leader-election
-              env:
-                - name: RUNTIME_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/notification-controller:v1.0.0-rc.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: healthz
-              name: manager
-              ports:
-                - containerPort: 9090
-                  name: http
-                  protocol: TCP
-                - containerPort: 9292
-                  name: http-webhook
-                  protocol: TCP
-                - containerPort: 8080
-                  name: http-prom
-                  protocol: TCP
-                - containerPort: 9440
-                  name: healthz
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /readyz
-                  port: healthz
-              resources:
-                limits: {}
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
-              volumeMounts:
-                - mountPath: /tmp
-                  name: temp
+          - args:
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/notification-controller:v1.0.0-rc.3
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9090
+              name: http
+              protocol: TCP
+            - containerPort: 9292
+              name: http-webhook
+              protocol: TCP
+            - containerPort: 8080
+              name: http-prom
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: healthz
+            resources:
+              limits: {}
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            volumeMounts:
+            - mountPath: /tmp
+              name: temp
           serviceAccountName: notification-controller
           terminationGracePeriodSeconds: 10
           volumes:
-            - emptyDir: {}
-              name: temp
+          - emptyDir: {}
+            name: temp

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
-        helm.sh/chart: flux2-2.7.0
+        app.kubernetes.io/version: 2.0.0-rc.3
+        helm.sh/chart: flux2-2.8.0
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,28 +22,28 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 0.41.1
-            helm.sh/chart: flux2-2.7.0
+            app.kubernetes.io/version: 2.0.0-rc.3
+            helm.sh/chart: flux2-2.8.0
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
           containers:
-          - command:
-            - /usr/local/bin/flux
-            - check
-            - --pre
-            - --namespace
-            - NAMESPACE
-            image: ghcr.io/fluxcd/flux-cli:v0.41.1
-            name: flux-cli
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
+            - command:
+                - /usr/local/bin/flux
+                - check
+                - --pre
+                - --namespace
+                - NAMESPACE
+              image: ghcr.io/fluxcd/flux-cli:v2.0.0-rc.3
+              name: flux-cli
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
           restartPolicy: Never
           serviceAccountName: RELEASE-NAME-flux-check

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -28,22 +28,22 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-            - command:
-                - /usr/local/bin/flux
-                - check
-                - --pre
-                - --namespace
-                - NAMESPACE
-              image: ghcr.io/fluxcd/flux-cli:v2.0.0-rc.3
-              name: flux-cli
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
+          - command:
+            - /usr/local/bin/flux
+            - check
+            - --pre
+            - --namespace
+            - NAMESPACE
+            image: ghcr.io/fluxcd/flux-cli:v2.0.0-rc.3
+            name: flux-cli
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
           restartPolicy: Never
           serviceAccountName: RELEASE-NAME-flux-check

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -28,65 +28,65 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-            - args:
-                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-                - --watch-all-namespaces=true
-                - --log-level=info
-                - --log-encoding=json
-                - --enable-leader-election
-                - --storage-path=/data
-                - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-              env:
-                - name: RUNTIME_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/source-controller:v1.0.0-rc.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: healthz
-              name: manager
-              ports:
-                - containerPort: 9090
-                  name: http
-                  protocol: TCP
-                - containerPort: 8080
-                  name: http-prom
-                  protocol: TCP
-                - containerPort: 9440
-                  name: healthz
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  path: /
-                  port: http
-              resources:
-                limits: {}
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                seccompProfile:
-                  type: RuntimeDefault
-              volumeMounts:
-                - mountPath: /data
-                  name: data
-                - mountPath: /tmp
-                  name: tmp
+          - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            - --storage-path=/data
+            - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+            env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ghcr.io/fluxcd/source-controller:v1.0.0-rc.3
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: healthz
+            name: manager
+            ports:
+            - containerPort: 9090
+              name: http
+              protocol: TCP
+            - containerPort: 8080
+              name: http-prom
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+            readinessProbe:
+              httpGet:
+                path: /
+                port: http
+            resources:
+              limits: {}
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            volumeMounts:
+            - mountPath: /data
+              name: data
+            - mountPath: /tmp
+              name: tmp
           securityContext:
             fsGroup: 1337
           serviceAccountName: source-controller
           terminationGracePeriodSeconds: 10
           volumes:
-            - emptyDir: {}
-              name: data
-            - emptyDir: {}
-              name: tmp
+          - emptyDir: {}
+            name: data
+          - emptyDir: {}
+            name: tmp

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 0.41.1
+        app.kubernetes.io/version: 2.0.0-rc.3
         control-plane: controller
-        helm.sh/chart: flux2-2.7.0
+        helm.sh/chart: flux2-2.8.0
       name: source-controller
     spec:
       replicas: 1
@@ -28,65 +28,65 @@ should match snapshot of default values:
         spec:
           automountServiceAccountToken: true
           containers:
-          - args:
-            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-            - --watch-all-namespaces=true
-            - --log-level=info
-            - --log-encoding=json
-            - --enable-leader-election
-            - --storage-path=/data
-            - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-            env:
-            - name: RUNTIME_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/source-controller:v0.36.0
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /healthz
-                port: healthz
-            name: manager
-            ports:
-            - containerPort: 9090
-              name: http
-              protocol: TCP
-            - containerPort: 8080
-              name: http-prom
-              protocol: TCP
-            - containerPort: 9440
-              name: healthz
-              protocol: TCP
-            readinessProbe:
-              httpGet:
-                path: /
-                port: http
-            resources:
-              limits: {}
-              requests:
-                cpu: 100m
-                memory: 64Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                - ALL
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
-            volumeMounts:
-            - mountPath: /data
-              name: data
-            - mountPath: /tmp
-              name: tmp
+            - args:
+                - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+                - --watch-all-namespaces=true
+                - --log-level=info
+                - --log-encoding=json
+                - --enable-leader-election
+                - --storage-path=/data
+                - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+              env:
+                - name: RUNTIME_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: ghcr.io/fluxcd/source-controller:v1.0.0-rc.3
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: healthz
+              name: manager
+              ports:
+                - containerPort: 9090
+                  name: http
+                  protocol: TCP
+                - containerPort: 8080
+                  name: http-prom
+                  protocol: TCP
+                - containerPort: 9440
+                  name: healthz
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: http
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - mountPath: /data
+                  name: data
+                - mountPath: /tmp
+                  name: tmp
           securityContext:
             fsGroup: 1337
           serviceAccountName: source-controller
           terminationGracePeriodSeconds: 10
           volumes:
-          - emptyDir: {}
-            name: data
-          - emptyDir: {}
-            name: tmp
+            - emptyDir: {}
+              name: data
+            - emptyDir: {}
+              name: tmp

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -260,7 +260,7 @@ imagePullSecrets: []
 # -- Array of extra K8s manifests to deploy
 extraObjects: []
 # Example usage from https://fluxcd.io/docs/components/source/buckets/#static-authentication
-# - apiVersion: source.toolkit.fluxcd.io/v1beta1
+# - apiVersion: source.toolkit.fluxcd.io/v1beta2
 #   kind: Bucket
 #   metadata:
 #     name: podinfo

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -20,7 +20,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v0.41.1
+  tag: v2.0.0-rc.3
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -33,7 +33,7 @@ cli:
 helmController:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v0.31.1
+  tag: v0.33.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -80,7 +80,7 @@ helmController:
 imageAutomationController:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v0.31.0
+  tag: v0.33.1
   resources:
     limits: {}
     # cpu: 1000m
@@ -107,7 +107,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v0.26.0
+  tag: v0.27.2
   resources:
     limits: {}
     # cpu: 1000m
@@ -134,7 +134,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v0.35.0
+  tag: v1.0.0-rc.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -181,7 +181,7 @@ kustomizeController:
 notificationController:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v0.33.0
+  tag: v1.0.0-rc.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -215,7 +215,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v0.36.0
+  tag: v1.0.0-rc.3
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR (could be a temporary item) updates the flux manifests/CRDs to use the latest version of flux (2.0.0-rc.3) for those who want to adopt the use of the Helm charts to bootstrap the cluster on the new version.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #172 

#### Special notes for your reviewer:
- Tried `make generate` and it sort of worked but kept added "U" as part of the CRDs.  Not exactly sure why that happened at this point.
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
