### PR TITLE
Support extraEnv value setting for all flux controllers

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.0.0"
+    - "[Added]: Support extraEnv value setting for all flux controllers"
 apiVersion: v2
 appVersion: 2.0.0
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.9.0
+version: 2.9.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -28,6 +28,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | helmController.container.additionalArgs | list | `[]` |  |
 | helmController.create | bool | `true` |  |
+| helmController.extraEnv | list | `[]` |  |
 | helmController.image | string | `"ghcr.io/fluxcd/helm-controller"` |  |
 | helmController.imagePullPolicy | object | `{}` |  |
 | helmController.labels | object | `{}` |  |
@@ -46,6 +47,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageAutomationController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | imageAutomationController.container.additionalArgs | list | `[]` |  |
 | imageAutomationController.create | bool | `true` |  |
+| imageAutomationController.extraEnv | list | `[]` |  |
 | imageAutomationController.image | string | `"ghcr.io/fluxcd/image-automation-controller"` |  |
 | imageAutomationController.imagePullPolicy | object | `{}` |  |
 | imageAutomationController.labels | object | `{}` |  |
@@ -65,6 +67,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageReflectionController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | imageReflectionController.container.additionalArgs | list | `[]` |  |
 | imageReflectionController.create | bool | `true` |  |
+| imageReflectionController.extraEnv | list | `[]` |  |
 | imageReflectionController.image | string | `"ghcr.io/fluxcd/image-reflector-controller"` |  |
 | imageReflectionController.imagePullPolicy | object | `{}` |  |
 | imageReflectionController.labels | object | `{}` |  |
@@ -85,6 +88,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizeController.container.additionalArgs | list | `[]` |  |
 | kustomizeController.create | bool | `true` |  |
 | kustomizeController.envFrom | object | `{"map":{"name":""},"secret":{"name":""}}` | Defines envFrom using a configmap and/or secret. |
+| kustomizeController.extraEnv | list | `[]` |  |
 | kustomizeController.extraSecretMounts | list | `[]` | Defines additional mounts with secrets. Secrets must be manually created in the namespace or with kustomizeController.secret |
 | kustomizeController.image | string | `"ghcr.io/fluxcd/kustomize-controller"` |  |
 | kustomizeController.imagePullPolicy | object | `{}` |  |
@@ -111,6 +115,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | notificationController.container.additionalArgs | list | `[]` |  |
 | notificationController.create | bool | `true` |  |
+| notificationController.extraEnv | list | `[]` |  |
 | notificationController.image | string | `"ghcr.io/fluxcd/notification-controller"` |  |
 | notificationController.imagePullPolicy | object | `{}` |  |
 | notificationController.labels | object | `{}` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -54,6 +54,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.helmController.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: {{ template "template.image" .Values.helmController }}
         {{- if .Values.helmController.imagePullPolicy }}
         imagePullPolicy: {{ .Values.helmController.imagePullPolicy }}

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -53,6 +53,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.imageAutomationController.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: {{ template "template.image" .Values.imageAutomationController }}
         {{- if .Values.imageAutomationController.imagePullPolicy }}
         imagePullPolicy: {{ .Values.imageAutomationController.imagePullPolicy }}

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -53,6 +53,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.imageReflectionController.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: {{ template "template.image" .Values.imageReflectionController }}
         {{- if .Values.imageReflectionController.imagePullPolicy }}
         imagePullPolicy: {{ .Values.imageReflectionController.imagePullPolicy }}

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -54,6 +54,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.kustomizeController.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if or (.Values.kustomizeController.envFrom.map.name) (.Values.kustomizeController.envFrom.secret.name) }}
         envFrom:
           {{- if .Values.kustomizeController.envFrom.map.name }}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -50,6 +50,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.notificationController.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: {{ template "template.image" .Values.notificationController }}
         {{- if .Values.notificationController.imagePullPolicy }}
         imagePullPolicy: {{ .Values.notificationController.imagePullPolicy }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.0.0
-            helm.sh/chart: flux2-2.9.0
+            helm.sh/chart: flux2-2.9.1
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.0.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.0
+        helm.sh/chart: flux2-2.9.1
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -48,6 +48,7 @@ helmController:
   labels: {}
   container:
     additionalArgs: []
+  extraEnv: []
   serviceAccount:
     create: true
     automount: true
@@ -95,6 +96,7 @@ imageAutomationController:
   labels: {}
   container:
     additionalArgs: []
+  extraEnv: []
   serviceAccount:
     create: true
     automount: true
@@ -122,6 +124,7 @@ imageReflectionController:
   labels: {}
   container:
     additionalArgs: []
+  extraEnv: []
   serviceAccount:
     create: true
     automount: true
@@ -149,6 +152,7 @@ kustomizeController:
   labels: {}
   container:
     additionalArgs: []
+  extraEnv: []
   serviceAccount:
     create: true
     automount: true
@@ -196,6 +200,7 @@ notificationController:
   labels: {}
   container:
     additionalArgs: []
+  extraEnv: []
   serviceAccount:
     create: true
     automount: true


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Add `extraEnv` helm value setting for all flux controllers. source-controller already has this. this change exposes the same across all controllers consistently.
In case of using kubeconfig reference in HelmReleases or Kustomizations to reconcile on remote clusters, and in such setups where Kubernetes API endpoints of those remote clusters could require going through an egress proxy for reachability.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
