### PR TITLE
chore: upgrade charts to Flux v2.0.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.0.0
+FLUX2_VERSION ?= v2.0.1
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.10.0
-appVersion: 2.0.0
+version: 1.10.1
+appVersion: 2.0.1
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.0.0"
+    - "[Chore]: Update App Version to upstream 2.0.1"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
-        helm.sh/chart: flux2-notification-1.10.0
+        app.kubernetes.io/version: 2.0.1
+        helm.sh/chart: flux2-notification-1.10.1
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
-        helm.sh/chart: flux2-notification-1.10.0
+        app.kubernetes.io/version: 2.0.1
+        helm.sh/chart: flux2-notification-1.10.1
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
-        helm.sh/chart: flux2-notification-1.10.0
+        app.kubernetes.io/version: 2.0.1
+        helm.sh/chart: flux2-notification-1.10.1
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.6.0
-appVersion: 2.0.0
+version: 1.6.1
+appVersion: 2.0.1
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.0.0"
+    - "[Chore]: Update App Version to upstream 2.0.1"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.0.0"` |  |
+| cli.tag | string | `"v2.0.1"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.6.0
+        helm.sh/chart: flux2-sync-1.6.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.6.0
+        helm.sh/chart: flux2-sync-1.6.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.6.0
+        helm.sh/chart: flux2-sync-1.6.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -17,7 +17,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.0.0
+  tag: v2.0.1
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Added]: Support extraEnv value setting for all flux controllers"
+    - "[Chore]: Update App Version to upstream 2.0.1"
 apiVersion: v2
-appVersion: 2.0.0
+appVersion: 2.0.1
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.9.1
+version: 2.9.2

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.9.2](https://img.shields.io/badge/Version-2.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.0.0"` |  |
+| cli.tag | string | `"v2.0.1"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
@@ -79,7 +79,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v0.29.0"` |  |
+| imageReflectionController.tag | string | `"v0.29.1"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -104,7 +104,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.0.0"` |  |
+| kustomizeController.tag | string | `"v1.0.1"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -160,6 +160,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.0.0"` |  |
+| sourceController.tag | string | `"v1.0.1"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | watchAllNamespaces | bool | `true` |  |

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -413,7 +412,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -443,7 +442,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -854,7 +852,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -522,7 +521,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -1704,7 +1702,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -2301,7 +2298,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -2807,7 +2803,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.0.1
         control-plane: controller
-        helm.sh/chart: flux2-2.9.1
+        helm.sh/chart: flux2-2.9.2
       name: helm-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.0.1
         control-plane: controller
-        helm.sh/chart: flux2-2.9.1
+        helm.sh/chart: flux2-2.9.2
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.0.1
         control-plane: controller
-        helm.sh/chart: flux2-2.9.1
+        helm.sh/chart: flux2-2.9.2
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/image-reflector-controller:v0.29.0
+            image: ghcr.io/fluxcd/image-reflector-controller:v0.29.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
-        helm.sh/chart: flux2-2.9.1
+        app.kubernetes.io/version: 2.0.1
+        helm.sh/chart: flux2-2.9.2
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.0.1
         control-plane: controller
-        helm.sh/chart: flux2-2.9.1
+        helm.sh/chart: flux2-2.9.2
       name: kustomize-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/kustomize-controller:v1.0.0
+            image: ghcr.io/fluxcd/kustomize-controller:v1.0.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.0.1
         control-plane: controller
-        helm.sh/chart: flux2-2.9.1
+        helm.sh/chart: flux2-2.9.2
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
-        helm.sh/chart: flux2-2.9.1
+        app.kubernetes.io/version: 2.0.1
+        helm.sh/chart: flux2-2.9.2
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.0.0
-            helm.sh/chart: flux2-2.9.1
+            app.kubernetes.io/version: 2.0.1
+            helm.sh/chart: flux2-2.9.2
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
             - --pre
             - --namespace
             - NAMESPACE
-            image: ghcr.io/fluxcd/flux-cli:v2.0.0
+            image: ghcr.io/fluxcd/flux-cli:v2.0.1
             name: flux-cli
             securityContext:
               allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.0
+        app.kubernetes.io/version: 2.0.1
         control-plane: controller
-        helm.sh/chart: flux2-2.9.1
+        helm.sh/chart: flux2-2.9.2
       name: source-controller
     spec:
       replicas: 1
@@ -41,7 +41,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/source-controller:v1.0.0
+            image: ghcr.io/fluxcd/source-controller:v1.0.1
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -20,7 +20,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.0.0
+  tag: v2.0.1
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -109,7 +109,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v0.29.0
+  tag: v0.29.1
   resources:
     limits: {}
     # cpu: 1000m
@@ -137,7 +137,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.0.0
+  tag: v1.0.1
   resources:
     limits: {}
     # cpu: 1000m
@@ -220,7 +220,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.0.0
+  tag: v1.0.1
   resources:
     limits: {}
     # cpu: 1000m

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -12,7 +12,7 @@ trap delete_temp_dir EXIT
 
 
 get_controller_values_attribute() {
-  echo "$(echo $1 | cut -d '/' -f5 | sed 's/reflector/reflection/' | sed 's/-./\U&/g' | tr -d '-')"
+  echo "$(echo $1 | cut -d '/' -f5 | $SED 's/reflector/reflection/' | $SED 's/-./\U&/g' | tr -d '-')"
 }
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

- Upgrades the helm charts to use the Flux2 v2.0.1 release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
