### PR TITLE
chore: upgrade charts to Flux v2.1.0 release

### DIFF
--- a/.github/workflows/e2e-sync.yaml
+++ b/.github/workflows/e2e-sync.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: helm/kind-action@v1.4.0
         with:
           cluster_name: kind
-          node_image: kindest/node:v1.24.15
+          node_image: kindest/node:v1.25.11
       - name: Setup Helm
         uses: fluxcd/pkg//actions/helm@main
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: helm/kind-action@v1.4.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          node_image: kindest/node:v1.24.15
+          node_image: kindest/node:v1.25.11
 
       - name: Run chart-testing (install) for flux2
         run: ct install --config ct.yaml --charts charts/flux2

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.0.1
+FLUX2_VERSION ?= v2.1.0
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.10.1
-appVersion: 2.0.1
+version: 1.11.0
+appVersion: 2.1.0
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.0.1"
+    - "[Chore]: Update App Version to upstream 2.1.0"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
-        helm.sh/chart: flux2-notification-1.10.1
+        app.kubernetes.io/version: 2.1.0
+        helm.sh/chart: flux2-notification-1.11.0
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
-        helm.sh/chart: flux2-notification-1.10.1
+        app.kubernetes.io/version: 2.1.0
+        helm.sh/chart: flux2-notification-1.11.0
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
-        helm.sh/chart: flux2-notification-1.10.1
+        app.kubernetes.io/version: 2.1.0
+        helm.sh/chart: flux2-notification-1.11.0
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.6.2
-appVersion: 2.0.1
+version: 1.7.0
+appVersion: 2.1.0
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Fix]: kubeconfig configuration for kustomization"
+    - "[Chore]: Update App Version to upstream 2.1.0"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.0.1"` |  |
+| cli.tag | string | `"v2.1.0"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.6.2
+        helm.sh/chart: flux2-sync-1.7.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.6.2
+        helm.sh/chart: flux2-sync-1.7.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.6.2
+        helm.sh/chart: flux2-sync-1.7.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.6.2
+        helm.sh/chart: flux2-sync-1.7.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -17,7 +17,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.0.1
+  tag: v2.1.0
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.0.1"
+    - "[Chore]: Update App Version to upstream 2.1.0"
 apiVersion: v2
-appVersion: 2.0.1
+appVersion: 2.1.0
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.9.2
+version: 2.10.0

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.9.2](https://img.shields.io/badge/Version-2.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.0.1"` |  |
+| cli.tag | string | `"v2.1.0"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
@@ -40,7 +40,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | helmController.serviceAccount.annotations | object | `{}` |  |
 | helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
-| helmController.tag | string | `"v0.35.0"` |  |
+| helmController.tag | string | `"v0.36.0"` |  |
 | helmController.tolerations | list | `[]` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -59,7 +59,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
-| imageAutomationController.tag | string | `"v0.35.0"` |  |
+| imageAutomationController.tag | string | `"v0.36.0"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -79,7 +79,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v0.29.1"` |  |
+| imageReflectionController.tag | string | `"v0.30.0"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -104,7 +104,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.0.1"` |  |
+| kustomizeController.tag | string | `"v1.1.0"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -129,7 +129,7 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | notificationController.serviceAccount.annotations | object | `{}` |  |
 | notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
-| notificationController.tag | string | `"v1.0.0"` |  |
+| notificationController.tag | string | `"v1.1.0"` |  |
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.service.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.service.labels | object | `{}` |  |
@@ -160,6 +160,6 @@ This helm chart is maintain and released by the fluxcd-community on a best effor
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.0.1"` |  |
+| sourceController.tag | string | `"v1.1.0"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | watchAllNamespaces | bool | `true` |  |

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -288,7 +288,9 @@ spec:
                     type: string
                 type: object
               interval:
-                description: Interval at which to reconcile the Helm release.
+                description: Interval at which to reconcile the Helm release. This
+                  interval is approximate and may be subject to jitter to ensure efficient
+                  use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               kubeConfig:

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -141,8 +141,20 @@ spec:
                           to the branch named. The branch is created using `.spec.checkout.branch`
                           as the starting point, if it doesn't already exist.
                         type: string
-                    required:
-                    - branch
+                      options:
+                        additionalProperties:
+                          type: string
+                        description: 'Options specifies the push options that are
+                          sent to the Git server when performing a push operation.
+                          For details, see: https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt'
+                        type: object
+                      refspec:
+                        description: 'Refspec specifies the Git Refspec to use for
+                          a push operation. If both Branch and Refspec are provided,
+                          then the commit is pushed to the branch and also using the
+                          specified refspec. For more details about Git Refspecs,
+                          see: https://git-scm.com/book/en/v2/Git-Internals-The-Refspec'
+                        type: string
                     type: object
                 required:
                 - commit

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -701,13 +701,15 @@ spec:
                 - namespaceSelectors
                 type: object
               certSecretRef:
-                description: "CertSecretRef can be given the name of a secret containing
-                  either or both of \n - a PEM-encoded client certificate (`certFile`)
-                  and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`)
+                description: "CertSecretRef can be given the name of a Secret containing
+                  either or both of \n - a PEM-encoded client certificate (`tls.crt`)
+                  and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`)
                   \n and whichever are supplied, will be used for connecting to the
                   registry. The client cert and key are useful if you are authenticating
                   with a certificate; the CA cert is useful if you are using a self-signed
-                  server certificate."
+                  server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`.
+                  \n Note: Support for the `caFile`, `certFile` and `keyFile` keys
+                  has been deprecated."
                 properties:
                   name:
                     description: Name of the referent.

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -176,6 +176,8 @@ spec:
                 type: array
               interval:
                 description: The interval at which to reconcile the Kustomization.
+                  This interval is approximate and may be subject to jitter to ensure
+                  efficient use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               kubeConfig:

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -680,8 +680,9 @@ spec:
                 maxLength: 2048
                 type: string
               certSecretRef:
-                description: CertSecretRef specifies the Secret containing a PEM-encoded
-                  CA certificate (`caFile`).
+                description: "CertSecretRef specifies the Secret containing a PEM-encoded
+                  CA certificate (in the `ca.crt` key). \n Note: Support for the `caFile`
+                  key has been deprecated."
                 properties:
                   name:
                     description: Name of the referent.
@@ -749,6 +750,7 @@ spec:
                 - grafana
                 - githubdispatch
                 - pagerduty
+                - datadog
                 type: string
               username:
                 description: Username specifies the name under which events are posted.

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -332,7 +332,9 @@ spec:
                 description: Insecure allows connecting to a non-TLS HTTP Endpoint.
                 type: boolean
               interval:
-                description: Interval at which to check the Endpoint for updates.
+                description: Interval at which the Bucket Endpoint is checked for
+                  updates. This interval is approximate and may be subject to jitter
+                  to ensure efficient use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               provider:
@@ -610,9 +612,21 @@ spec:
                   type: object
                 type: array
               interval:
-                description: Interval at which to check the GitRepository for updates.
+                description: Interval at which the GitRepository URL is checked for
+                  updates. This interval is approximate and may be subject to jitter
+                  to ensure efficient use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
+              proxySecretRef:
+                description: ProxySecretRef specifies the Secret containing the proxy
+                  configuration to use while communicating with the Git server.
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
               recurseSubmodules:
                 description: RecurseSubmodules enables the initialization of all submodules
                   within the GitRepository as cloned from the URL, using their default
@@ -679,10 +693,16 @@ spec:
                   Git commit signature(s).
                 properties:
                   mode:
-                    description: Mode specifies what Git object should be verified,
-                      currently ('head').
+                    default: HEAD
+                    description: "Mode specifies which Git object(s) should be verified.
+                      \n The variants \"head\" and \"HEAD\" both imply the same thing,
+                      i.e. verify the commit that the HEAD of the Git repository points
+                      to. The variant \"head\" solely exists to ensure backwards compatibility."
                     enum:
                     - head
+                    - HEAD
+                    - Tag
+                    - TagAndHEAD
                     type: string
                   secretRef:
                     description: SecretRef specifies the Secret containing the public
@@ -695,7 +715,6 @@ spec:
                     - name
                     type: object
                 required:
-                - mode
                 - secretRef
                 type: object
             required:
@@ -918,6 +937,10 @@ spec:
                 description: ObservedRecurseSubmodules is the observed resource submodules
                   configuration used to produce the current Artifact.
                 type: boolean
+              sourceVerificationMode:
+                description: SourceVerificationMode is the last used verification
+                  mode indicating which Git object(s) have been verified.
+                type: string
             type: object
         type: object
     served: true
@@ -2050,8 +2073,9 @@ spec:
                   at in the SourceRef.
                 type: string
               interval:
-                description: Interval is the interval at which to check the Source
-                  for updates.
+                description: Interval at which the HelmChart SourceRef is checked
+                  for updates. This interval is approximate and may be subject to
+                  jitter to ensure efficient use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               reconcileStrategy:
@@ -2596,8 +2620,27 @@ spec:
                 required:
                 - namespaceSelectors
                 type: object
+              certSecretRef:
+                description: "CertSecretRef can be given the name of a Secret containing
+                  either or both of \n - a PEM-encoded client certificate (`tls.crt`)
+                  and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`)
+                  \n and whichever are supplied, will be used for connecting to the
+                  registry. The client cert and key are useful if you are authenticating
+                  with a certificate; the CA cert is useful if you are using a self-signed
+                  server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`.
+                  \n It takes precedence over the values specified in the Secret referred
+                  to by `.spec.secretRef`."
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
               interval:
-                description: Interval at which to check the URL for updates.
+                description: Interval at which the HelmRepository URL is checked for
+                  updates. This interval is approximate and may be subject to jitter
+                  to ensure efficient use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               passCredentials:
@@ -2623,8 +2666,9 @@ spec:
               secretRef:
                 description: SecretRef specifies the Secret containing authentication
                   credentials for the HelmRepository. For HTTP/S basic auth the secret
-                  must contain 'username' and 'password' fields. For TLS the secret
-                  must contain a 'certFile' and 'keyFile', and/or 'caFile' fields.
+                  must contain 'username' and 'password' fields. Support for TLS auth
+                  using the 'certFile' and 'keyFile', and/or 'caFile' keys is deprecated.
+                  Please use `.spec.certSecretRef` instead.
                 properties:
                   name:
                     description: Name of the referent.
@@ -2855,13 +2899,15 @@ spec:
             description: OCIRepositorySpec defines the desired state of OCIRepository
             properties:
               certSecretRef:
-                description: "CertSecretRef can be given the name of a secret containing
-                  either or both of \n - a PEM-encoded client certificate (`certFile`)
-                  and private key (`keyFile`); - a PEM-encoded CA certificate (`caFile`)
+                description: "CertSecretRef can be given the name of a Secret containing
+                  either or both of \n - a PEM-encoded client certificate (`tls.crt`)
+                  and private key (`tls.key`); - a PEM-encoded CA certificate (`ca.crt`)
                   \n and whichever are supplied, will be used for connecting to the
                   registry. The client cert and key are useful if you are authenticating
                   with a certificate; the CA cert is useful if you are using a self-signed
-                  server certificate."
+                  server certificate. The Secret must be of type `Opaque` or `kubernetes.io/tls`.
+                  \n Note: Support for the `caFile`, `certFile` and `keyFile` keys
+                  have been deprecated."
                 properties:
                   name:
                     description: Name of the referent.
@@ -2880,7 +2926,9 @@ spec:
                   registry.
                 type: boolean
               interval:
-                description: The interval at which to check for image updates.
+                description: Interval at which the OCIRepository URL is checked for
+                  updates. This interval is approximate and may be subject to jitter
+                  to ensure efficient use of resources.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               layerSelector:

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
+        app.kubernetes.io/version: 2.1.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.2
+        helm.sh/chart: flux2-2.10.0
       name: helm-controller
     spec:
       replicas: 1
@@ -39,7 +39,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/helm-controller:v0.35.0
+            image: ghcr.io/fluxcd/helm-controller:v0.36.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
+        app.kubernetes.io/version: 2.1.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.2
+        helm.sh/chart: flux2-2.10.0
       name: image-automation-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/image-automation-controller:v0.35.0
+            image: ghcr.io/fluxcd/image-automation-controller:v0.36.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
+        app.kubernetes.io/version: 2.1.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.2
+        helm.sh/chart: flux2-2.10.0
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/image-reflector-controller:v0.29.1
+            image: ghcr.io/fluxcd/image-reflector-controller:v0.30.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
-        helm.sh/chart: flux2-2.9.2
+        app.kubernetes.io/version: 2.1.0
+        helm.sh/chart: flux2-2.10.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
+        app.kubernetes.io/version: 2.1.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.2
+        helm.sh/chart: flux2-2.10.0
       name: kustomize-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/kustomize-controller:v1.0.1
+            image: ghcr.io/fluxcd/kustomize-controller:v1.1.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
+        app.kubernetes.io/version: 2.1.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.2
+        helm.sh/chart: flux2-2.10.0
       name: notification-controller
     spec:
       replicas: 1
@@ -36,7 +36,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/notification-controller:v1.0.0
+            image: ghcr.io/fluxcd/notification-controller:v1.1.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
-        helm.sh/chart: flux2-2.9.2
+        app.kubernetes.io/version: 2.1.0
+        helm.sh/chart: flux2-2.10.0
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.0.1
-            helm.sh/chart: flux2-2.9.2
+            app.kubernetes.io/version: 2.1.0
+            helm.sh/chart: flux2-2.10.0
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
             - --pre
             - --namespace
             - NAMESPACE
-            image: ghcr.io/fluxcd/flux-cli:v2.0.1
+            image: ghcr.io/fluxcd/flux-cli:v2.1.0
             name: flux-cli
             securityContext:
               allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -7,9 +7,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.0.1
+        app.kubernetes.io/version: 2.1.0
         control-plane: controller
-        helm.sh/chart: flux2-2.9.2
+        helm.sh/chart: flux2-2.10.0
       name: source-controller
     spec:
       replicas: 1
@@ -41,7 +41,7 @@ should match snapshot of default values:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ghcr.io/fluxcd/source-controller:v1.0.1
+            image: ghcr.io/fluxcd/source-controller:v1.1.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -20,7 +20,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.0.1
+  tag: v2.1.0
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -33,7 +33,7 @@ cli:
 helmController:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v0.35.0
+  tag: v0.36.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -81,7 +81,7 @@ helmController:
 imageAutomationController:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v0.35.0
+  tag: v0.36.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -109,7 +109,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v0.29.1
+  tag: v0.30.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -137,7 +137,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.0.1
+  tag: v1.1.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -185,7 +185,7 @@ kustomizeController:
 notificationController:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v1.0.0
+  tag: v1.1.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -220,7 +220,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.0.1
+  tag: v1.1.0
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
- Upgrades the helm charts to use the Flux2 v2.1.0 release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/fluxcd-community/helm-charts/issues/182

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
