### PR TITLE
Remove --helm3 flag from unittest

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -35,7 +35,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm env
-          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.2.11
+          helm plugin install https://github.com/quintush/helm-unittest.git --version 0.3.5
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Once changes have been merged, the release job will automatically run to package
 
 * Make your changes
 * run: ```helm install --dry-run charts/flux2/ --generate-name```
-* run: ```helm unittest --helm3 --file 'tests/*.yaml' charts/flux2/```
+* run: ```helm unittest --file 'tests/*.yaml' charts/flux2/```
     * add ```-u``` if you need to update the compare snapshot in \_\_snapshots\_\_
 * bump chart version if necessary
 * run: ```make helmdocs```

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ generate: fetch
 	@$(OK) Generating CRDs
 
 unittests:
-	@helm unittest --helm3 --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2-multi-tenancy/
-	@helm unittest --helm3 --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2/
-	@helm unittest --helm3 --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2-sync/
-	@helm unittest --helm3 --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2-notification/
+	@helm unittest --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2-multi-tenancy/
+	@helm unittest --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2/
+	@helm unittest --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2-sync/
+	@helm unittest --file tests/*.yaml --file 'tests/**/*.yaml' charts/flux2-notification/
 
 check-diff:
 	@$(INFO) checking that branch is clean

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,4 +3,4 @@ remote: origin
 target-branch: main
 validate-maintainers: false
 additional-commands:
-  - helm unittest --helm3 --strict --file tests/*.yaml --file 'tests/**/*.yaml' {{ .Path }}
+  - helm unittest --strict --file tests/*.yaml --file 'tests/**/*.yaml' {{ .Path }}


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
--helm3 does not exist anymore

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #196

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] helm-docs are updated
- [ ] Helm chart is tested
- [ ] Update artifacthub.io/changes in Chart.yaml
- [ ] Run `make reviewable`
