### PR TITLE
Add `app.kubernetes.io/component` label to flux controllers

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.10.5
+version: 2.10.6

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.10.5](https://img.shields.io/badge/Version-2.10.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
+![Version: 2.10.6](https://img.shields.io/badge/Version-2.10.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.2](https://img.shields.io/badge/AppVersion-2.1.2-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/templates/helm-controller-sa.yaml
+++ b/charts/flux2/templates/helm-controller-sa.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: helm-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: helm-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: helm-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/image-automation-controller-sa.yaml
+++ b/charts/flux2/templates/image-automation-controller-sa.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: image-automation-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: image-automation-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: image-automation-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/image-reflector-controller-sa.yaml
+++ b/charts/flux2/templates/image-reflector-controller-sa.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: image-reflector-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: image-reflector-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux
@@ -413,6 +414,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: image-reflector-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: image-reflector-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/kustomize-controller-sa.yaml
+++ b/charts/flux2/templates/kustomize-controller-sa.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: kustomize-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: kustomize-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: kustomize-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/notification-controller-sa.yaml
+++ b/charts/flux2/templates/notification-controller-sa.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/source-controller-serviceaccount.yaml
+++ b/charts/flux2/templates/source-controller-serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux
@@ -524,6 +525,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux
@@ -1726,6 +1728,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux
@@ -2323,6 +2326,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux
@@ -2848,6 +2852,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: source-controller
     app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -4,12 +4,13 @@ should match snapshot of default values:
     kind: Deployment
     metadata:
       labels:
+        app.kubernetes.io/component: helm-controller
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
         control-plane: controller
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -4,12 +4,13 @@ should match snapshot of default values:
     kind: Deployment
     metadata:
       labels:
+        app.kubernetes.io/component: image-automation-controller
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
         control-plane: controller
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -4,12 +4,13 @@ should match snapshot of default values:
     kind: Deployment
     metadata:
       labels:
+        app.kubernetes.io/component: image-reflector-controller
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
         control-plane: controller
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -4,12 +4,13 @@ should match snapshot of default values:
     kind: Deployment
     metadata:
       labels:
+        app.kubernetes.io/component: kustomize-controller
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
         control-plane: controller
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -4,12 +4,13 @@ should match snapshot of default values:
     kind: Deployment
     metadata:
       labels:
+        app.kubernetes.io/component: notification-controller
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
         control-plane: controller
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.1.2
-            helm.sh/chart: flux2-2.10.5
+            helm.sh/chart: flux2-2.10.6
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -4,12 +4,13 @@ should match snapshot of default values:
     kind: Deployment
     metadata:
       labels:
+        app.kubernetes.io/component: source-controller
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.1.2
         control-plane: controller
-        helm.sh/chart: flux2-2.10.5
+        helm.sh/chart: flux2-2.10.6
       name: source-controller
     spec:
       replicas: 1


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
`flux` cli assigns `app.kubernetes.io/component` labels to the component controllers. This pr does the same when installed using helm chart.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [ ] Helm chart is tested
- [c] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
