### PR TITLE
feat(alert-spec): Adding alertspec, eventmetadata/inclusionlist

### DIFF
--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.13.1
+version: 1.14.0
 appVersion: 2.2.2
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
+![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/templates/alert.yaml
+++ b/charts/flux2-notification/templates/alert.yaml
@@ -21,6 +21,12 @@ spec:
   {{- with $alert.spec.eventSources }}
   eventSources: {{ toYaml . | nindent 4 }}
   {{- end }}
+  {{- with $alert.spec.eventMetadata }}
+  eventMetadata: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $alert.spec.inclusionList }}
+  inclusionList: {{ toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $alert.spec.exclusionList }}
   exclusionList: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-notification-1.13.1
+        helm.sh/chart: flux2-notification-1.14.0
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-notification-1.13.1
+        helm.sh/chart: flux2-notification-1.14.0
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -8,7 +8,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-notification-1.13.1
+        helm.sh/chart: flux2-notification-1.14.0
       name: webhook-url
       namespace: NAMESPACE
     stringData:


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR will help to include `eventMetadata` and `inclusionList` to the Flux2 notification chart template (alert.yaml) in alert spec (Kind). 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #
This is not indented to fix any current issues. Updating the kind alert spec (notification.toolkit.fluxcd.io/v1beta3).
Reference: https://github.com/fluxcd/notification-controller/blob/api/v1.2.3/api/v1beta3/alert_types.go#L31 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [ ] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
