### PR TITLE
chore: upgrade charts to Flux v2.2.3 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.2.2
+FLUX2_VERSION ?= v2.2.3
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.14.0
-appVersion: 2.2.2
+version: 1.14.1
+appVersion: 2.2.3
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.2.2"
+    - "[Chore]: Update App Version to upstream 2.2.3"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
+![Version: 1.14.1](https://img.shields.io/badge/Version-1.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-notification-1.14.0
+        app.kubernetes.io/version: 2.2.3
+        helm.sh/chart: flux2-notification-1.14.1
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-notification-1.14.0
+        app.kubernetes.io/version: 2.2.3
+        helm.sh/chart: flux2-notification-1.14.1
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-notification-1.14.0
+        app.kubernetes.io/version: 2.2.3
+        helm.sh/chart: flux2-notification-1.14.1
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.8.1
-appVersion: 2.2.2
+version: 1.8.2
+appVersion: 2.2.3
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.2.2"
+    - "[Chore]: Update App Version to upstream 2.2.3"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.8.1](https://img.shields.io/badge/Version-1.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
+![Version: 1.8.2](https://img.shields.io/badge/Version-1.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.2.2"` |  |
+| cli.tag | string | `"v2.2.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.8.1
+        helm.sh/chart: flux2-sync-1.8.2
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.8.1
+        helm.sh/chart: flux2-sync-1.8.2
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.8.1
+        helm.sh/chart: flux2-sync-1.8.2
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.8.1
+        helm.sh/chart: flux2-sync-1.8.2
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -17,7 +17,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.2.2
+  tag: v2.2.3
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.2.2"
+    - "[Chore]: Update App Version to upstream 2.2.3"
 apiVersion: v2
-appVersion: 2.2.2
+appVersion: 2.2.3
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.12.2
+version: 2.12.3

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.12.2](https://img.shields.io/badge/Version-2.12.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=flat-square)
+![Version: 2.12.3](https://img.shields.io/badge/Version-2.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.2.2"` |  |
+| cli.tag | string | `"v2.2.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
@@ -41,7 +41,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | helmController.serviceAccount.annotations | object | `{}` |  |
 | helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
-| helmController.tag | string | `"v0.37.2"` |  |
+| helmController.tag | string | `"v0.37.4"` |  |
 | helmController.tolerations | list | `[]` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -60,7 +60,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
-| imageAutomationController.tag | string | `"v0.37.0"` |  |
+| imageAutomationController.tag | string | `"v0.37.1"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -80,7 +80,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v0.31.1"` |  |
+| imageReflectionController.tag | string | `"v0.31.2"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -105,7 +105,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.2.1"` |  |
+| kustomizeController.tag | string | `"v1.2.2"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -130,7 +130,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | notificationController.serviceAccount.annotations | object | `{}` |  |
 | notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
-| notificationController.tag | string | `"v1.2.3"` |  |
+| notificationController.tag | string | `"v1.2.4"` |  |
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.ingress.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.ingress.create | bool | `false` |  |
@@ -169,6 +169,6 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.2.3"` |  |
+| sourceController.tag | string | `"v1.2.4"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | watchAllNamespaces | bool | `true` |  |

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux
@@ -584,6 +585,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux
@@ -1122,6 +1124,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   labels:
+    app.kubernetes.io/component: notification-controller
     app.kubernetes.io/instance: '{{ .Release.Namespace }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
     app.kubernetes.io/part-of: flux

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
+        app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.2
+        helm.sh/chart: flux2-2.12.3
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/helm-controller:v0.37.2
+              image: ghcr.io/fluxcd/helm-controller:v0.37.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
+        app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.2
+        helm.sh/chart: flux2-2.12.3
       name: image-automation-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-automation-controller:v0.37.0
+              image: ghcr.io/fluxcd/image-automation-controller:v0.37.1
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
+        app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.2
+        helm.sh/chart: flux2-2.12.3
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-reflector-controller:v0.31.1
+              image: ghcr.io/fluxcd/image-reflector-controller:v0.31.2
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-2.12.2
+        app.kubernetes.io/version: 2.2.3
+        helm.sh/chart: flux2-2.12.3
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
+        app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.2
+        helm.sh/chart: flux2-2.12.3
       name: kustomize-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/kustomize-controller:v1.2.1
+              image: ghcr.io/fluxcd/kustomize-controller:v1.2.2
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
+        app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.2
+        helm.sh/chart: flux2-2.12.3
       name: notification-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/notification-controller:v1.2.3
+              image: ghcr.io/fluxcd/notification-controller:v1.2.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
-        helm.sh/chart: flux2-2.12.2
+        app.kubernetes.io/version: 2.2.3
+        helm.sh/chart: flux2-2.12.3
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.2.2
-            helm.sh/chart: flux2-2.12.2
+            app.kubernetes.io/version: 2.2.3
+            helm.sh/chart: flux2-2.12.3
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --pre
                 - --namespace
                 - NAMESPACE
-              image: ghcr.io/fluxcd/flux-cli:v2.2.2
+              image: ghcr.io/fluxcd/flux-cli:v2.2.3
               name: flux-cli
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.2.2
+        app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.2
+        helm.sh/chart: flux2-2.12.3
       name: source-controller
     spec:
       replicas: 1
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/source-controller:v1.2.3
+              image: ghcr.io/fluxcd/source-controller:v1.2.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -23,7 +23,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.2.2
+  tag: v2.2.3
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -36,7 +36,7 @@ cli:
 helmController:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v0.37.2
+  tag: v0.37.4
   resources:
     limits: {}
     # cpu: 1000m
@@ -84,7 +84,7 @@ helmController:
 imageAutomationController:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v0.37.0
+  tag: v0.37.1
   resources:
     limits: {}
     # cpu: 1000m
@@ -112,7 +112,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v0.31.1
+  tag: v0.31.2
   resources:
     limits: {}
     # cpu: 1000m
@@ -140,7 +140,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.2.1
+  tag: v1.2.2
   resources:
     limits: {}
     # cpu: 1000m
@@ -188,7 +188,7 @@ kustomizeController:
 notificationController:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v1.2.3
+  tag: v1.2.4
   resources:
     limits: {}
     # cpu: 1000m
@@ -241,7 +241,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.2.3
+  tag: v1.2.4
   resources:
     limits: {}
     # cpu: 1000m

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -19,12 +19,14 @@ get_controller_values_attribute() {
 for FILE in `cat .work/flux2/manifests/crds/kustomization.yaml | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%:-]*"`
 do
 
+component="$(echo ${FILE} | cut -d '/' -f5)"
 cat <<EOF > "${TEMPDIR}/global-labels.yaml"
 apiVersion: builtin
 kind: LabelTransformer
 metadata:
   name: global-labels
 labels:
+  app.kubernetes.io/component: ${component}
   app.kubernetes.io/instance: "{{ .Release.Namespace }}"
   app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   app.kubernetes.io/version: "{{ .Chart.AppVersion }}"


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

- Upgrades the helm charts to use the Flux2 v2.2.3 release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
NA

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
