### PR TITLE
Make cluster role name configurable

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.12.3
+version: 2.12.4

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.12.3](https://img.shields.io/badge/Version-2.12.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
+![Version: 2.12.4](https://img.shields.io/badge/Version-2.12.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/templates/cluster-reconciler-clusterrolebinding.yaml
+++ b/charts/flux2/templates/cluster-reconciler-clusterrolebinding.yaml
@@ -15,7 +15,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: {{ .Values.rbac.roleRef.name }}
 subjects:
 - kind: ServiceAccount
   name: kustomize-controller

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.2.3
-            helm.sh/chart: flux2-2.12.3
+            helm.sh/chart: flux2-2.12.4
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.3
+        helm.sh/chart: flux2-2.12.4
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
+++ b/charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
@@ -38,3 +38,10 @@ tests:
           path: metadata.annotations
           value:
             helm.sh/resource-policy: keep
+  - it: should set clusterrole name
+    set:
+      rbac.roleRef.name: test-clusterrole
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: test-clusterrole

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -278,6 +278,8 @@ rbac:
   createAggregation: true
   # -- Add annotations to all RBAC resources, e.g. "helm.sh/resource-policy": keep
   annotations: {}
+  roleRef:
+    name: cluster-admin
 
 logLevel: info
 watchAllNamespaces: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Users should be able to assign a lower-scope ClusterRole to the reconciler which does not have full cluster admin privileges. This PR replaces the hardcoded name with a value

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Helm chart is tested
- [x] Run `make reviewable`
