### PR TITLE
Limit crd-controller access to installed CRDs

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.2.3"
+    - "[Feature]: Limit crd-controller access to installed CRDs"
 apiVersion: v2
 appVersion: 2.2.3
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.12.4
+version: 2.12.5

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.12.4](https://img.shields.io/badge/Version-2.12.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
+![Version: 2.12.5](https://img.shields.io/badge/Version-2.12.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.3](https://img.shields.io/badge/AppVersion-2.2.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -150,6 +150,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | rbac.annotations | object | `{}` | Add annotations to all RBAC resources, e.g. "helm.sh/resource-policy": keep |
 | rbac.create | bool | `true` |  |
 | rbac.createAggregation | bool | `true` | Grant the Kubernetes view, edit and admin roles access to Flux custom resources |
+| rbac.roleRef.name | string | `"cluster-admin"` |  |
 | sourceController.affinity | object | `{}` |  |
 | sourceController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | sourceController.annotations."prometheus.io/scrape" | string | `"true"` |  |

--- a/charts/flux2/templates/crd-controller-clusterrole.yaml
+++ b/charts/flux2/templates/crd-controller-clusterrole.yaml
@@ -13,21 +13,31 @@ metadata:
     app.kubernetes.io/part-of: flux
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 rules:
+{{- if .Values.sourceController.create }}
 - apiGroups: ['source.toolkit.fluxcd.io']
   resources: ['*']
   verbs: ['*']
+{{- end }}
+{{- if and .Values.kustomizeController.create }}
 - apiGroups: ['kustomize.toolkit.fluxcd.io']
   resources: ['*']
   verbs: ['*']
+{{- end }}
+{{- if and .Values.helmController.create}}
 - apiGroups: ['helm.toolkit.fluxcd.io']
   resources: ['*']
   verbs: ['*']
+{{- end }}
+{{- if and .Values.notificationController.create }}
 - apiGroups: ['notification.toolkit.fluxcd.io']
   resources: ['*']
   verbs: ['*']
+{{- end }}
+{{- if or .Values.imageAutomationController.create .Values.imageReflectionController.create }}
 - apiGroups: ['image.toolkit.fluxcd.io']
   resources: ['*']
   verbs: ['*']
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/flux2/templates/crd-controller-clusterrolebinding.yaml
+++ b/charts/flux2/templates/crd-controller-clusterrolebinding.yaml
@@ -17,22 +17,34 @@ roleRef:
   kind: ClusterRole
   name: crd-controller
 subjects:
-  - kind: ServiceAccount
-    name: kustomize-controller
-    namespace: {{ .Release.Namespace }}
-  - kind: ServiceAccount
-    name: helm-controller
-    namespace: {{ .Release.Namespace }}
+{{- if .Values.sourceController.create }}
   - kind: ServiceAccount
     name: source-controller
     namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.kustomizeController.create }}
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.helmController.create}}
+  - kind: ServiceAccount
+    name: helm-controller
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.notificationController.create }}
   - kind: ServiceAccount
     name: notification-controller
     namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.imageReflectionController.create }}
   - kind: ServiceAccount
     name: image-reflector-controller
     namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.imageAutomationController.create }}
   - kind: ServiceAccount
     name: image-automation-controller
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.2.3
-            helm.sh/chart: flux2-2.12.4
+            helm.sh/chart: flux2-2.12.5
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.2.3
         control-plane: controller
-        helm.sh/chart: flux2-2.12.4
+        helm.sh/chart: flux2-2.12.5
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/crd-controller-clusterrole_test.yaml
+++ b/charts/flux2/tests/crd-controller-clusterrole_test.yaml
@@ -1,0 +1,25 @@
+suite: test crd controller clusterrole
+templates:
+  - crd-controller-clusterrole.yaml
+tests:
+  - it: should add rules only for enabled components
+    set:
+      sourceController.create: true
+      kustomizeController.create: false
+      helmController.create: true
+      notificationController.create: true
+      imageReflectionController.create: false
+      imageAutomationController.create: true
+    asserts:
+      - equal:
+          path: rules[0].apiGroups
+          value: ['source.toolkit.fluxcd.io']
+      - equal:
+          path: rules[1].apiGroups
+          value: ['helm.toolkit.fluxcd.io']
+      - equal:
+          path: rules[2].apiGroups
+          value: ['notification.toolkit.fluxcd.io']
+      - equal:
+          path: rules[3].apiGroups
+          value: ['image.toolkit.fluxcd.io']         

--- a/charts/flux2/tests/crd-controller-clusterrolebinding_test.yaml
+++ b/charts/flux2/tests/crd-controller-clusterrolebinding_test.yaml
@@ -1,0 +1,25 @@
+suite: test crd controller clusterrolebinding
+templates:
+  - crd-controller-clusterrolebinding.yaml
+tests:
+  - it: should add subjects only for enabled components
+    set:
+      sourceController.create: true
+      kustomizeController.create: false
+      helmController.create: true
+      notificationController.create: true
+      imageReflectionController.create: false
+      imageAutomationController.create: true
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: source-controller
+      - equal:
+          path: subjects[1].name
+          value: helm-controller
+      - equal:
+          path: subjects[2].name
+          value: notification-controller
+      - equal:
+          path: subjects[3].name
+          value: image-automation-controller        


### PR DESCRIPTION
#### What this PR does / why we need it:

Limit the access given to the crd-controler ClusterRole based on the enabled flux components. Similarly create ClusterRoleBinding only when the target component and SA is enabled.

#### Checklist
- [ ] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
