### PR TITLE
Setting name for gitrepository/kustomization

### DIFF
--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.9.0
+version: 1.10.0
 appVersion: 2.3.0
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.2.3"
+    - "[Feat]: Set custom name for gitrepository/kustomization"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -21,6 +21,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |
+| gitRepository.name | string | `""` |  |
 | gitRepository.spec.gitImplementation | string | `""` | _Optional_ Determines which git client library to use. Defaults to go-git, valid values are (‘go-git’, ‘libgit2’). |
 | gitRepository.spec.ignore | string | `""` | _Optional_ Ignore overrides the set of excluded patterns in the .sourceignore format (which is the same as .gitignore). If not provided, a default will be used, consult the documentation for your version to find out what those are. Make sure to set this as yaml multiline string. |
 | gitRepository.spec.include | list | `[]` | _Optional_ Extra git repositories to map into the repository |
@@ -34,6 +35,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | gitRepository.spec.verify | object | `{}` | _Optional_ Verify OpenPGP signature for the Git commit HEAD points to. |
 | kustomization.annotations | object | `{}` |  |
 | kustomization.labels | object | `{}` |  |
+| kustomization.name | string | `""` |  |
 | kustomization.spec.decryption | object | `{}` | _Optional_ Decrypt Kubernetes secrets before applying them on the cluster. |
 | kustomization.spec.dependsOn | list | `[]` | _Optional_ DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to Kustomization resources that must be ready before this Kustomization can be reconciled. |
 | kustomization.spec.force | bool | `false` | _Optional_ Force instructs the controller to recreate resources when patching fails due to an immutable field change. Defaults to false. |

--- a/charts/flux2-sync/templates/flux-gitrepository.yaml
+++ b/charts/flux2-sync/templates/flux-gitrepository.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- with .Values.gitRepository.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
 {{- end }}
-  name: {{ .Release.Name }}
+  name: {{ .Values.gitRepository.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   url: {{ .Values.gitRepository.spec.url }}

--- a/charts/flux2-sync/templates/flux-kustomization.yaml
+++ b/charts/flux2-sync/templates/flux-kustomization.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- with .Values.kustomization.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
 {{- end }}
-  name:  {{ .Release.Name }}
+  name:  {{ .Values.kustomization.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   {{- with .Values.kustomization.spec.dependsOn }}
@@ -48,7 +48,7 @@ spec:
   {{- end }}
   sourceRef:
     kind: GitRepository
-    name: {{ .Release.Name }}
+    name: {{ .Values.gitRepository.name | default .Release.Name }}
   {{- if .Values.kustomization.spec.suspend }}
   suspend: {{ .Values.kustomization.spec.suspend }}
   {{- end }}

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.9.0
+        helm.sh/chart: flux2-sync-1.10.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.9.0
+        helm.sh/chart: flux2-sync-1.10.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.9.0
+        helm.sh/chart: flux2-sync-1.10.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.9.0
+        helm.sh/chart: flux2-sync-1.10.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -25,6 +25,7 @@ cli:
 gitRepository:
   labels: {}
   annotations: {}
+  name: ""
   spec:
     # -- The repository URL, can be an HTTP/S or SSH address.
     url: ""
@@ -67,6 +68,7 @@ gitRepository:
 kustomization:
   labels: {}
   annotations: {}
+  name: ""
   spec:
     # -- _Optional_ DependsOn may contain a dependency.CrossNamespaceDependencyReference slice with references to Kustomization resources that must be ready before this Kustomization can be reconciled.
     dependsOn: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Feature that add ability to set custom name for gitrepository/kustomization flux-sync resources

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] helm-docs are updated
- [ ] Helm chart is tested
- [ ] Update artifacthub.io/changes in Chart.yaml
- [ ] Run `make reviewable`
