### PR TITLE
add support for annotations for the source and kustomize controller deployments

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.13.0
+version: 2.13.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -88,6 +88,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | kustomizeController.container.additionalArgs | list | `[]` |  |
 | kustomizeController.create | bool | `true` |  |
+| kustomizeController.deploymentAnnotations | object | `{}` |  |
 | kustomizeController.envFrom | object | `{"map":{"name":""},"secret":{"name":""}}` | Defines envFrom using a configmap and/or secret. |
 | kustomizeController.extraEnv | list | `[]` |  |
 | kustomizeController.extraSecretMounts | list | `[]` | Defines additional mounts with secrets. Secrets must be manually created in the namespace or with kustomizeController.secret |
@@ -156,6 +157,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | sourceController.container.additionalArgs | list | `[]` |  |
 | sourceController.create | bool | `true` |  |
+| sourceController.deploymentAnnotations | object | `{}` |  |
 | sourceController.extraEnv | list | `[]` |  |
 | sourceController.image | string | `"ghcr.io/fluxcd/source-controller"` |  |
 | sourceController.imagePullPolicy | string | `""` |  |

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -13,6 +13,10 @@ metadata:
     {{- with .Values.kustomizeController.labels }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- with .Values.kustomizeController.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
   name: kustomize-controller
 spec:
   {{- if kindIs "invalid" .Values.kustomizeController.replicas }}

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -13,10 +13,10 @@ metadata:
     {{- with .Values.kustomizeController.labels }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+  {{- with .Values.kustomizeController.deploymentAnnotations }}
   annotations:
-    {{- with .Values.kustomizeController.deploymentAnnotations }}
     {{- . | toYaml | nindent 4 }}
-    {{- end }}
+  {{- end }}
   name: kustomize-controller
 spec:
   {{- if kindIs "invalid" .Values.kustomizeController.replicas }}

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.kustomizeController.annotations }}
+    {{- with .Values.kustomizeController.deploymentAnnotations }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   name: kustomize-controller

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.sourceController.annotations }}
+    {{- with .Values.sourceController.deploymentAnnotations }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   name: source-controller

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -13,10 +13,10 @@ metadata:
     {{- with .Values.sourceController.labels }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+  {{- with .Values.sourceController.deploymentAnnotations }}
   annotations:
-    {{- with .Values.sourceController.deploymentAnnotations }}
     {{- . | toYaml | nindent 4 }}
-    {{- end }}
+  {{- end }}
   name: source-controller
 spec:
   replicas: 1

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -13,6 +13,10 @@ metadata:
     {{- with .Values.sourceController.labels }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+  annotations:
+    {{- with .Values.sourceController.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
   name: source-controller
 spec:
   replicas: 1

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
         control-plane: controller
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
         control-plane: controller
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
         control-plane: controller
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
         control-plane: controller
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
         control-plane: controller
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.3.0
-            helm.sh/chart: flux2-2.13.0
+            helm.sh/chart: flux2-2.13.1
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.3.0
         control-plane: controller
-        helm.sh/chart: flux2-2.13.0
+        helm.sh/chart: flux2-2.13.1
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -152,6 +152,7 @@ kustomizeController:
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
+  deploymentAnnotations: {}
   labels: {}
   container:
     additionalArgs: []
@@ -253,6 +254,7 @@ sourceController:
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scrape: "true"
+  deploymentAnnotations: {}
   labels: {}
   container:
     additionalArgs: []


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR adds the ability to add deployment annotaiton to the deployments of kustomize and source controller.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
