### PR TITLE
fix(charts/flux2,crds): crds.annotations got respected now

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.4.0"
+    - "fix(charts/flux2,crds): crds.annotations got respected now"
 apiVersion: v2
 appVersion: 2.4.0
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.14.0
+version: 2.14.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: helm-controller

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: image-automation-controller

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: image-reflector-controller
@@ -415,6 +418,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: image-reflector-controller

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: kustomize-controller

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: notification-controller
@@ -586,6 +589,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: notification-controller
@@ -1128,6 +1134,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: notification-controller

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: source-controller
@@ -994,6 +997,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: source-controller
@@ -2258,6 +2264,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: source-controller
@@ -3241,6 +3250,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: source-controller
@@ -4092,6 +4104,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    {{- with .Values.crds.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.1
   labels:
     app.kubernetes.io/component: source-controller

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.4.0
-            helm.sh/chart: flux2-2.14.0
+            helm.sh/chart: flux2-2.14.1
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: source-controller
     spec:
       replicas: 1

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -49,6 +49,7 @@ EOF
 attribute="$(get_controller_values_attribute ${FILE})"
 echo "{{- if and .Values.installCRDs .Values.${attribute}.create }}" > ./charts/flux2/templates/${FILE##*/}
 kubectl kustomize "${TEMPDIR}" >> ./charts/flux2/templates/${FILE##*/}
+$SED -Ei '/^  annotations:/a\ \ \ \ {{- with .Values.crds.annotations }}\n\ \ \ \ {{- . | toYaml | nindent 4 }}\n\ \ \ \ {{- end }}' ./charts/flux2/templates/${FILE##*/}
 echo "{{- end }}">> ./charts/flux2/templates/${FILE##*/}
 
 # git diff --quiet will exit 1 when there are changes.


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

In the flux2 helm chart there is already the possibility to set the value `crds.annotations`. Unfortunately, this value is not used anywhere because the corresponding templates are missing in the crds. With this merge request I want to add templating to the generated crds so that this value can not only be set without meaning, but also so that the annotations in the crds can actually be customised.

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x]  helm-docs are updated
  - didn't change anything
- [x] Helm chart is tested
- [x]  Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
