### PR TITLE
feat(charts/flux2): adding option for container.name

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.4.0"
+    - "add[charts/flux2]: adding option for container.name"
 apiVersion: v2
 appVersion: 2.4.0
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.14.0
+version: 2.14.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -28,6 +28,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | helmController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | helmController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | helmController.container.additionalArgs | list | `[]` |  |
+| helmController.container.name | string | `"manager"` |  |
 | helmController.create | bool | `true` |  |
 | helmController.extraEnv | list | `[]` |  |
 | helmController.image | string | `"ghcr.io/fluxcd/helm-controller"` |  |
@@ -47,6 +48,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | imageAutomationController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | imageAutomationController.container.additionalArgs | list | `[]` |  |
+| imageAutomationController.container.name | string | `"manager"` |  |
 | imageAutomationController.create | bool | `true` |  |
 | imageAutomationController.extraEnv | list | `[]` |  |
 | imageAutomationController.image | string | `"ghcr.io/fluxcd/image-automation-controller"` |  |
@@ -67,6 +69,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageReflectionController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | imageReflectionController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | imageReflectionController.container.additionalArgs | list | `[]` |  |
+| imageReflectionController.container.name | string | `"manager"` |  |
 | imageReflectionController.create | bool | `true` |  |
 | imageReflectionController.extraEnv | list | `[]` |  |
 | imageReflectionController.image | string | `"ghcr.io/fluxcd/image-reflector-controller"` |  |
@@ -87,6 +90,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | kustomizeController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | kustomizeController.container.additionalArgs | list | `[]` |  |
+| kustomizeController.container.name | string | `"manager"` |  |
 | kustomizeController.create | bool | `true` |  |
 | kustomizeController.envFrom | object | `{"map":{"name":""},"secret":{"name":""}}` | Defines envFrom using a configmap and/or secret. |
 | kustomizeController.extraEnv | list | `[]` |  |
@@ -115,6 +119,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | notificationController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | notificationController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | notificationController.container.additionalArgs | list | `[]` |  |
+| notificationController.container.name | string | `"manager"` |  |
 | notificationController.create | bool | `true` |  |
 | notificationController.extraEnv | list | `[]` |  |
 | notificationController.image | string | `"ghcr.io/fluxcd/notification-controller"` |  |
@@ -155,6 +160,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.annotations."prometheus.io/port" | string | `"8080"` |  |
 | sourceController.annotations."prometheus.io/scrape" | string | `"true"` |  |
 | sourceController.container.additionalArgs | list | `[]` |  |
+| sourceController.container.name | string | `"manager"` |  |
 | sourceController.create | bool | `true` |  |
 | sourceController.extraEnv | list | `[]` |  |
 | sourceController.image | string | `"ghcr.io/fluxcd/source-controller"` |  |

--- a/charts/flux2/templates/helm-controller.yaml
+++ b/charts/flux2/templates/helm-controller.yaml
@@ -71,7 +71,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
-        name: manager
+        name: {{ .Values.helmController.container.name | default "manager" }}
         ports:
         - containerPort: 8080
           name: http-prom

--- a/charts/flux2/templates/image-automation-controller.yaml
+++ b/charts/flux2/templates/image-automation-controller.yaml
@@ -70,7 +70,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
-        name: manager
+        name: {{ .Values.imageAutomationController.container.name | default "manager" }}
         ports:
         - containerPort: 8080
           name: http-prom

--- a/charts/flux2/templates/image-reflector-controller.yaml
+++ b/charts/flux2/templates/image-reflector-controller.yaml
@@ -70,7 +70,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
-        name: manager
+        name: {{ .Values.imageReflectionController.container.name | default "manager" }}
         ports:
         - containerPort: 8080
           name: http-prom

--- a/charts/flux2/templates/kustomize-controller.yaml
+++ b/charts/flux2/templates/kustomize-controller.yaml
@@ -82,7 +82,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
-        name: manager
+        name: {{ .Values.kustomizeController.container.name | default "manager" }}
         ports:
         - containerPort: 8080
           name: http-prom

--- a/charts/flux2/templates/notification-controller.yaml
+++ b/charts/flux2/templates/notification-controller.yaml
@@ -67,7 +67,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
-        name: manager
+        name: {{ .Values.notificationController.container.name | default "manager" }}
         ports:
         - containerPort: 9090
           name: http

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -67,7 +67,7 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
-        name: manager
+        name: {{ .Values.sourceController.container.name | default "manager" }}
         ports:
         - containerPort: 9090
           name: http

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.4.0
-            helm.sh/chart: flux2-2.14.0
+            helm.sh/chart: flux2-2.14.1
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.0
+        helm.sh/chart: flux2-2.14.1
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -50,6 +50,9 @@ helmController:
     prometheus.io/scrape: "true"
   labels: {}
   container:
+    name: manager
+    # for example:
+    # name: helm-controller
     additionalArgs: []
   extraEnv: []
   serviceAccount:
@@ -98,6 +101,9 @@ imageAutomationController:
     prometheus.io/scrape: "true"
   labels: {}
   container:
+    name: manager
+    # for example:
+    # name: image-automation-controller
     additionalArgs: []
   extraEnv: []
   serviceAccount:
@@ -126,6 +132,9 @@ imageReflectionController:
     prometheus.io/scrape: "true"
   labels: {}
   container:
+    name: manager
+    # for example:
+    # name: image-reflector-controller
     additionalArgs: []
   extraEnv: []
   serviceAccount:
@@ -155,6 +164,9 @@ kustomizeController:
   labels: {}
   container:
     additionalArgs: []
+    name: manager
+    # for example:
+    # name: kustomize-controller
   extraEnv: []
   serviceAccount:
     create: true
@@ -202,6 +214,9 @@ notificationController:
     prometheus.io/scrape: "true"
   labels: {}
   container:
+    name: manager
+    # for example:
+    # name: notification-controller
     additionalArgs: []
   extraEnv: []
   serviceAccount:
@@ -255,6 +270,9 @@ sourceController:
     prometheus.io/scrape: "true"
   labels: {}
   container:
+    name: manager
+    # for example:
+    # name: source-controller
     additionalArgs: []
   serviceAccount:
     create: true


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Feature that add ability to set custom name for container.name in flux2 resources

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #230

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
