### PR TITLE
Adding interval-jitter-percentage as chart parameter

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "fix(charts/flux2,crds): crds.annotations got respected now"
+    - "feat(charts/flux2): add interval-jitter-percentage parameter for source controller"
 apiVersion: v2
 appVersion: 2.4.0
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.14.1
+version: 2.14.2

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 2.14.2](https://img.shields.io/badge/Version-2.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -159,6 +159,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.extraEnv | list | `[]` |  |
 | sourceController.image | string | `"ghcr.io/fluxcd/source-controller"` |  |
 | sourceController.imagePullPolicy | string | `""` |  |
+| sourceController.intervalJitterPercentage | int | `10` |  |
 | sourceController.labels | object | `{}` |  |
 | sourceController.nodeSelector | object | `{}` |  |
 | sourceController.priorityClassName | string | `""` |  |

--- a/charts/flux2/templates/source-controller.yaml
+++ b/charts/flux2/templates/source-controller.yaml
@@ -46,6 +46,7 @@ spec:
         - --enable-leader-election
         - --storage-path=/data
         - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.{{ .Values.clusterDomain | default "cluster.local" }}.
+        - --interval-jitter-percentage={{ .Values.sourceController.intervalJitterPercentage }}
         {{- range .Values.sourceController.container.additionalArgs }}
         - {{ . }}
         {{- end}}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.4.0
-            helm.sh/chart: flux2-2.14.1
+            helm.sh/chart: flux2-2.14.2
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.4.0
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.14.2
       name: source-controller
     spec:
       replicas: 1
@@ -37,6 +37,7 @@ should match snapshot of default values:
                 - --enable-leader-election
                 - --storage-path=/data
                 - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+                - --interval-jitter-percentage=10
               env:
                 - name: RUNTIME_NAMESPACE
                   valueFrom:

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -268,6 +268,7 @@ sourceController:
   affinity: {}
   tolerations: []
   extraEnv: []
+  intervalJitterPercentage: 10
 
 policies:
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Expose parameter `interval-jitter-percentage` as an optional value in the Helm chart.

#### Which issue this PR fixes
 
 - fixes #236 
 
#### Checklist
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`