### PR TITLE
chore: upgrade charts to Flux v2.5.1 release

### DIFF
--- a/.github/workflows/e2e-sync.yaml
+++ b/.github/workflows/e2e-sync.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: helm/kind-action@v1.4.0
         with:
           cluster_name: kind
-          node_image: kindest/node:v1.28.0
+          node_image: kindest/node:v1.30.10
       - name: Setup Helm
         uses: fluxcd/pkg//actions/helm@main
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: helm/kind-action@v1.7.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
-          node_image: kindest/node:v1.28.0
+          node_image: kindest/node:v1.30.10
 
       - name: Run chart-testing (install) for flux2
         run: ct install --config ct.yaml --charts charts/flux2

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.4.0
+FLUX2_VERSION ?= v2.5.1
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.16.0
-appVersion: 2.4.0
+version: 1.17.0
+appVersion: 2.5.1
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.4.0"
+    - "[Chore]: Update App Version to upstream 2.5.1"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 1.17.0](https://img.shields.io/badge/Version-1.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-notification-1.16.0
+        app.kubernetes.io/version: 2.5.1
+        helm.sh/chart: flux2-notification-1.17.0
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-notification-1.16.0
+        app.kubernetes.io/version: 2.5.1
+        helm.sh/chart: flux2-notification-1.17.0
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-notification-1.16.0
+        app.kubernetes.io/version: 2.5.1
+        helm.sh/chart: flux2-notification-1.17.0
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.10.0
-appVersion: 2.4.0
+version: 1.11.0
+appVersion: 2.5.1
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.4.0"
+    - "[Chore]: Update App Version to upstream 2.5.1"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.4.0"` |  |
+| cli.tag | string | `"v2.5.1"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.10.0
+        helm.sh/chart: flux2-sync-1.11.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.10.0
+        helm.sh/chart: flux2-sync-1.11.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.10.0
+        helm.sh/chart: flux2-sync-1.11.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.10.0
+        helm.sh/chart: flux2-sync-1.11.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -17,7 +17,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.4.0
+  tag: v2.5.1
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "fix(charts/flux2,crds): crds.annotations got respected now"
+    - "[Chore]: Update App Version to upstream 2.5.1"
 apiVersion: v2
-appVersion: 2.4.0
+appVersion: 2.5.1
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.14.1
+version: 2.15.0

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.14.1](https://img.shields.io/badge/Version-2.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 2.15.0](https://img.shields.io/badge/Version-2.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.4.0"` |  |
+| cli.tag | string | `"v2.5.1"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
@@ -41,7 +41,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | helmController.serviceAccount.annotations | object | `{}` |  |
 | helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
-| helmController.tag | string | `"v1.1.0"` |  |
+| helmController.tag | string | `"v1.2.0"` |  |
 | helmController.tolerations | list | `[]` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -60,7 +60,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
-| imageAutomationController.tag | string | `"v0.39.0"` |  |
+| imageAutomationController.tag | string | `"v0.40.0"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -80,7 +80,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v0.33.0"` |  |
+| imageReflectionController.tag | string | `"v0.34.0"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -105,7 +105,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.4.0"` |  |
+| kustomizeController.tag | string | `"v1.5.1"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -130,7 +130,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | notificationController.serviceAccount.annotations | object | `{}` |  |
 | notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
-| notificationController.tag | string | `"v1.4.0"` |  |
+| notificationController.tag | string | `"v1.5.0"` |  |
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.ingress.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.ingress.create | bool | `false` |  |
@@ -170,6 +170,6 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.4.1"` |  |
+| sourceController.tag | string | `"v1.5.0"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | watchAllNamespaces | bool | `true` |  |

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -380,6 +380,11 @@ spec:
                       DisableSchemaValidation prevents the Helm install action from validating
                       the values against the JSON Schema.
                     type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm install action. Defaults to false.
+                    type: boolean
                   disableWait:
                     description: |-
                       DisableWait disables the waiting for resources to be ready after a Helm
@@ -793,6 +798,11 @@ spec:
                     description: |-
                       DisableSchemaValidation prevents the Helm upgrade action from validating
                       the values against the JSON Schema.
+                    type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm upgrade action. Defaults to false.
                     type: boolean
                   disableWait:
                     description: |-

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -437,6 +437,13 @@ spec:
                           MessageTemplate provides a template for the commit message,
                           into which will be interpolated the details of the change made.
                         type: string
+                      messageTemplateValues:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          MessageTemplateValues provides additional values to be available to the
+                          templating rendering.
+                        type: object
                       signingKey:
                         description: SigningKey provides the option to sign commits
                           with a GPG key

--- a/charts/flux2/templates/kustomize-controller.crds.yaml
+++ b/charts/flux2/templates/kustomize-controller.crds.yaml
@@ -108,6 +108,17 @@ spec:
                 required:
                 - provider
                 type: object
+              deletionPolicy:
+                description: |-
+                  DeletionPolicy can be used to control garbage collection when this
+                  Kustomization is deleted. Valid values are ('MirrorPrune', 'Delete',
+                  'Orphan'). 'MirrorPrune' mirrors the Prune field (orphan if false,
+                  delete if true). Defaults to 'MirrorPrune'.
+                enum:
+                - MirrorPrune
+                - Delete
+                - Orphan
+                type: string
               dependsOn:
                 description: |-
                   DependsOn may contain a meta.NamespacedObjectReference slice
@@ -135,6 +146,42 @@ spec:
                   Force instructs the controller to recreate resources
                   when patching fails due to an immutable field change.
                 type: boolean
+              healthCheckExprs:
+                description: |-
+                  HealthCheckExprs is a list of healthcheck expressions for evaluating the
+                  health of custom resources using Common Expression Language (CEL).
+                  The expressions are evaluated only when Wait or HealthChecks are specified.
+                items:
+                  description: CustomHealthCheck defines the health check for custom
+                    resources.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the custom resource under evaluation.
+                      type: string
+                    current:
+                      description: |-
+                        Current is the CEL expression that determines if the status
+                        of the custom resource has reached the desired state.
+                      type: string
+                    failed:
+                      description: |-
+                        Failed is the CEL expression that determines if the status
+                        of the custom resource has failed to reach the desired state.
+                      type: string
+                    inProgress:
+                      description: |-
+                        InProgress is the CEL expression that determines if the status
+                        of the custom resource has not yet reached the desired state.
+                      type: string
+                    kind:
+                      description: Kind of the custom resource under evaluation.
+                      type: string
+                  required:
+                  - apiVersion
+                  - current
+                  - kind
+                  type: object
+                type: array
               healthChecks:
                 description: A list of resources to be included in the health assessment.
                 items:
@@ -519,6 +566,14 @@ spec:
                 required:
                 - entries
                 type: object
+              lastAppliedOriginRevision:
+                description: |-
+                  The last successfully applied origin revision.
+                  Equals the origin revision of the applied Artifact from the referenced Source.
+                  Usually present on the Metadata of the applied Artifact and depends on the
+                  Source type, e.g. for OCI it's the value associated with the key
+                  "org.opencontainers.image.revision".
+                type: string
               lastAppliedRevision:
                 description: |-
                   The last successfully applied revision.

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -567,8 +567,9 @@ spec:
                 - name
                 type: object
               summary:
-                description: Summary holds a short description of the impact and affected
-                  cluster.
+                description: |-
+                  Summary holds a short description of the impact and affected cluster.
+                  Deprecated: Use EventMetadata instead.
                 maxLength: 255
                 type: string
               suspend:
@@ -1202,6 +1203,16 @@ spec:
                 description: Interval at which to reconcile the Receiver with its
                   Secret references.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              resourceFilter:
+                description: |-
+                  ResourceFilter is a CEL expression expected to return a boolean that is
+                  evaluated for each resource referenced in the Resources field when a
+                  webhook is received. If the expression returns false then the controller
+                  will not request a reconciliation for the resource.
+                  When the expression is specified the controller will parse it and mark
+                  the object as terminally failed if the expression is invalid or does not
+                  return a boolean.
                 type: string
               resources:
                 description: A list of resources to be notified about changes.

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -1109,11 +1109,12 @@ spec:
                 type: string
               provider:
                 description: |-
-                  Provider used for authentication, can be 'azure', 'generic'.
+                  Provider used for authentication, can be 'azure', 'github', 'generic'.
                   When not specified, defaults to 'generic'.
                 enum:
                 - generic
                 - azure
+                - github
                 type: string
               proxySecretRef:
                 description: |-

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.1
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.15.0
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/helm-controller:v1.1.0
+              image: ghcr.io/fluxcd/helm-controller:v1.2.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.1
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.15.0
       name: image-automation-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-automation-controller:v0.39.0
+              image: ghcr.io/fluxcd/image-automation-controller:v0.40.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.1
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.15.0
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-reflector-controller:v0.33.0
+              image: ghcr.io/fluxcd/image-reflector-controller:v0.34.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.1
+        app.kubernetes.io/version: 2.5.1
+        helm.sh/chart: flux2-2.15.0
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.1
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.15.0
       name: kustomize-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/kustomize-controller:v1.4.0
+              image: ghcr.io/fluxcd/kustomize-controller:v1.5.1
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.1
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.15.0
       name: notification-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/notification-controller:v1.4.0
+              image: ghcr.io/fluxcd/notification-controller:v1.5.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
-        helm.sh/chart: flux2-2.14.1
+        app.kubernetes.io/version: 2.5.1
+        helm.sh/chart: flux2-2.15.0
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.4.0
-            helm.sh/chart: flux2-2.14.1
+            app.kubernetes.io/version: 2.5.1
+            helm.sh/chart: flux2-2.15.0
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --pre
                 - --namespace
                 - NAMESPACE
-              image: ghcr.io/fluxcd/flux-cli:v2.4.0
+              image: ghcr.io/fluxcd/flux-cli:v2.5.1
               name: flux-cli
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.4.0
+        app.kubernetes.io/version: 2.5.1
         control-plane: controller
-        helm.sh/chart: flux2-2.14.1
+        helm.sh/chart: flux2-2.15.0
       name: source-controller
     spec:
       replicas: 1
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/source-controller:v1.4.1
+              image: ghcr.io/fluxcd/source-controller:v1.5.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -23,7 +23,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.4.0
+  tag: v2.5.1
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -36,7 +36,7 @@ cli:
 helmController:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v1.1.0
+  tag: v1.2.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -84,7 +84,7 @@ helmController:
 imageAutomationController:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v0.39.0
+  tag: v0.40.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -112,7 +112,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v0.33.0
+  tag: v0.34.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -140,7 +140,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.4.0
+  tag: v1.5.1
   resources:
     limits: {}
     # cpu: 1000m
@@ -188,7 +188,7 @@ kustomizeController:
 notificationController:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v1.4.0
+  tag: v1.5.0
   resources:
     limits: {}
     # cpu: 1000m
@@ -241,7 +241,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.4.1
+  tag: v1.5.0
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

- Upgrades the helm charts to use the Flux2 v2.5.1 release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
