### PR TITLE
chore: upgrade charts to Flux v2.7.3 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.7.2
+FLUX2_VERSION ?= v2.7.3
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.19.0
-appVersion: 2.7.2
+version: 1.19.1
+appVersion: 2.7.3
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.7.2"
+    - "[Chore]: Update App Version to upstream 2.7.3"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.19.0](https://img.shields.io/badge/Version-1.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 1.19.1](https://img.shields.io/badge/Version-1.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
-        helm.sh/chart: flux2-notification-1.19.0
+        app.kubernetes.io/version: 2.7.3
+        helm.sh/chart: flux2-notification-1.19.1
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
-        helm.sh/chart: flux2-notification-1.19.0
+        app.kubernetes.io/version: 2.7.3
+        helm.sh/chart: flux2-notification-1.19.1
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
-        helm.sh/chart: flux2-notification-1.19.0
+        app.kubernetes.io/version: 2.7.3
+        helm.sh/chart: flux2-notification-1.19.1
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.14.0
-appVersion: 2.7.2
+version: 1.14.1
+appVersion: 2.7.3
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.7.2"
+    - "[Chore]: Update App Version to upstream 2.7.3"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 1.14.1](https://img.shields.io/badge/Version-1.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.7.2"` |  |
+| cli.tag | string | `"v2.7.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.0
+        helm.sh/chart: flux2-sync-1.14.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.0
+        helm.sh/chart: flux2-sync-1.14.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.0
+        helm.sh/chart: flux2-sync-1.14.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.0
+        helm.sh/chart: flux2-sync-1.14.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -18,7 +18,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.7.2
+  tag: v2.7.3
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.7.2"
+    - "[Chore]: Update App Version to upstream 2.7.3"
 apiVersion: v2
-appVersion: 2.7.2
+appVersion: 2.7.3
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.17.0
+version: 2.17.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.17.0](https://img.shields.io/badge/Version-2.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 2.17.1](https://img.shields.io/badge/Version-2.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,10 +19,11 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.7.2"` |  |
+| cli.tag | string | `"v2.7.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
+| crds.migration | object | `{"affinity":{},"annotations":{},"enabled":false,"nodeSelector":{},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"64Mi"}},"tolerations":[]}` | Enable Flux CRs migration using helm pre upgrade hook job |
 | distro.openshift | bool | `false` |  |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmController.affinity | object | `{}` |  |
@@ -42,7 +43,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | helmController.serviceAccount.annotations | object | `{}` |  |
 | helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
-| helmController.tag | string | `"v1.4.2"` |  |
+| helmController.tag | string | `"v1.4.3"` |  |
 | helmController.tolerations | list | `[]` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -61,7 +62,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
-| imageAutomationController.tag | string | `"v1.0.2"` |  |
+| imageAutomationController.tag | string | `"v1.0.3"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -81,7 +82,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v1.0.2"` |  |
+| imageReflectionController.tag | string | `"v1.0.3"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -106,7 +107,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.7.1"` |  |
+| kustomizeController.tag | string | `"v1.7.2"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -131,7 +132,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | notificationController.serviceAccount.annotations | object | `{}` |  |
 | notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
-| notificationController.tag | string | `"v1.7.3"` |  |
+| notificationController.tag | string | `"v1.7.4"` |  |
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.ingress.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.ingress.create | bool | `false` |  |
@@ -171,7 +172,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.7.2"` |  |
+| sourceController.tag | string | `"v1.7.3"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | sourceWatcher.affinity | object | `{}` |  |
 | sourceWatcher.annotations."prometheus.io/port" | string | `"8080"` |  |

--- a/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
+++ b/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.crds.migration.enabled -}}
+{{- if and .Values.rbac.create .Values.multitenancy.enabled (not .Values.multitenancy.privileged) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-flux-migrate
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions/status
+    verbs:
+    - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-flux-migrate
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-flux-migrate
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: {{ .Release.Namespace }}
+---
+{{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-flux-migrate"
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      {{- with .Values.crds.migration.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+        app.kubernetes.io/part-of: flux
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: "kustomize-controller"
+      containers:
+      - name: flux-cli-migrate
+        image: {{ template "template.image" .Values.cli }}
+        command: ["/usr/local/bin/flux", "migrate"]
+        {{- with .Values.crds.migration.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.crds.migration.securityContext }}
+        securityContext: {{ toYaml .Values.crds.migration.securityContext | nindent 10 }}
+        {{- else }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        {{- end}}
+        {{- if .Values.crds.migration.volumeMounts }}
+        volumeMounts:
+        {{- toYaml .Values.crds.migration.volumeMounts | nindent 10 }}
+        {{- end}}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
+      {{- with .Values.crds.migration.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.crds.migration.volumes }}
+      volumes:
+      {{- toYaml .Values.crds.migration.volumes | nindent 8 }}
+      {{- end}}
+      {{- with .Values.crds.migration.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crds.migration.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
+        app.kubernetes.io/version: 2.7.3
         control-plane: controller
-        helm.sh/chart: flux2-2.17.0
+        helm.sh/chart: flux2-2.17.1
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/helm-controller:v1.4.2
+              image: ghcr.io/fluxcd/helm-controller:v1.4.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
+        app.kubernetes.io/version: 2.7.3
         control-plane: controller
-        helm.sh/chart: flux2-2.17.0
+        helm.sh/chart: flux2-2.17.1
       name: image-automation-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-automation-controller:v1.0.2
+              image: ghcr.io/fluxcd/image-automation-controller:v1.0.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
+        app.kubernetes.io/version: 2.7.3
         control-plane: controller
-        helm.sh/chart: flux2-2.17.0
+        helm.sh/chart: flux2-2.17.1
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-reflector-controller:v1.0.2
+              image: ghcr.io/fluxcd/image-reflector-controller:v1.0.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
-        helm.sh/chart: flux2-2.17.0
+        app.kubernetes.io/version: 2.7.3
+        helm.sh/chart: flux2-2.17.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
+        app.kubernetes.io/version: 2.7.3
         control-plane: controller
-        helm.sh/chart: flux2-2.17.0
+        helm.sh/chart: flux2-2.17.1
       name: kustomize-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/kustomize-controller:v1.7.1
+              image: ghcr.io/fluxcd/kustomize-controller:v1.7.2
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
+        app.kubernetes.io/version: 2.7.3
         control-plane: controller
-        helm.sh/chart: flux2-2.17.0
+        helm.sh/chart: flux2-2.17.1
       name: notification-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/notification-controller:v1.7.3
+              image: ghcr.io/fluxcd/notification-controller:v1.7.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
-        helm.sh/chart: flux2-2.17.0
+        app.kubernetes.io/version: 2.7.3
+        helm.sh/chart: flux2-2.17.1
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.7.2
-            helm.sh/chart: flux2-2.17.0
+            app.kubernetes.io/version: 2.7.3
+            helm.sh/chart: flux2-2.17.1
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --pre
                 - --namespace
                 - NAMESPACE
-              image: ghcr.io/fluxcd/flux-cli:v2.7.2
+              image: ghcr.io/fluxcd/flux-cli:v2.7.3
               name: flux-cli
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
+        app.kubernetes.io/version: 2.7.3
         control-plane: controller
-        helm.sh/chart: flux2-2.17.0
+        helm.sh/chart: flux2-2.17.1
       name: source-controller
     spec:
       replicas: 1
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/source-controller:v1.7.2
+              image: ghcr.io/fluxcd/source-controller:v1.7.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot with default values when enabled:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
+        app.kubernetes.io/version: 2.7.3
         control-plane: controller
-        helm.sh/chart: flux2-2.17.0
+        helm.sh/chart: flux2-2.17.1
       name: source-watcher
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -4,6 +4,20 @@ installCRDs: true
 crds:
   # -- Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep
   annotations: {}
+  # -- Enable Flux CRs migration using helm pre upgrade hook job
+  migration:
+    enabled: false
+    resources:
+      limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 64Mi
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    annotations: {}
 
 multitenancy:
   # -- Implement the patches for Multi-tenancy lockdown.
@@ -23,7 +37,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.7.2
+  tag: v2.7.3
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -36,7 +50,7 @@ cli:
 helmController:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v1.4.2
+  tag: v1.4.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -84,7 +98,7 @@ helmController:
 imageAutomationController:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v1.0.2
+  tag: v1.0.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -112,7 +126,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v1.0.2
+  tag: v1.0.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -140,7 +154,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.7.1
+  tag: v1.7.2
   resources:
     limits: {}
     # cpu: 1000m
@@ -188,7 +202,7 @@ kustomizeController:
 notificationController:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v1.7.3
+  tag: v1.7.4
   resources:
     limits: {}
     # cpu: 1000m
@@ -241,7 +255,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.7.2
+  tag: v1.7.3
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

- Upgrades the helm charts to use the Flux2 v2.7.3 patch release.
- Adds a `pre-upgrade` helm hook job, which runs `flux migrate` to migrate the Flux Custom Resources to their latest API versions. the hook is disabled by default, can be enabled by value settings `crds.migration.enabled` to `true`. 

#### Which issue this PR fixes

#### Special notes for your reviewer:

- I've tested the pre-upgrade hook job by deploying the chart locally, with `--set crds.migration.enabled=true` and verified that it renders as expected and successful job completion on multitenancy enabled and privileged disabled setup. the migrate job uses the `kustomize-controller` serviceaccount, which has `cluster-admin` clusterrole binded, with chart default values.  In case of multitenancy enabled and privileged disabled setup, additional rbac access for get, list and update on CRD resource are granted.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
