### PR TITLE
feat(flux2): add flag for optionally disabling pre-install checks

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.7.2"
+    - "[Chore]: Allow Disabling Pre-Install Job"
 apiVersion: v2
 appVersion: 2.7.2
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.17.0
+version: 2.17.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.17.0](https://img.shields.io/badge/Version-2.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
+![Version: 2.17.1](https://img.shields.io/badge/Version-2.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.2](https://img.shields.io/badge/AppVersion-2.7.2-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -16,6 +16,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 |-----|------|---------|-------------|
 | cli.affinity | object | `{}` |  |
 | cli.annotations | object | `{}` |  |
+| cli.create | bool | `true` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |

--- a/charts/flux2/templates/pre-install-job-serviceaccount.yaml
+++ b/charts/flux2/templates/pre-install-job-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cli.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,3 +13,4 @@ metadata:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- end }}

--- a/charts/flux2/templates/pre-install-job.yaml
+++ b/charts/flux2/templates/pre-install-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cli.create }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -70,3 +71,4 @@ spec:
       {{- with .Values.cli.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/flux2/tests/pre-install-job_test.yaml
+++ b/charts/flux2/tests/pre-install-job_test.yaml
@@ -104,3 +104,9 @@ tests:
   - it: should match snapshot of default values
     asserts:
       - matchSnapshot: {}
+  - it: should not render job when cli.create is false
+    set:
+      cli.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -22,6 +22,7 @@ multitenancy:
 clusterDomain: cluster.local
 
 cli:
+  create: true
   image: ghcr.io/fluxcd/flux-cli
   tag: v2.7.2
   nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR adds a `cli.create` field, and updates the pre-install job and SA templates to be rendered conditionally. 

The `flux check` preflight check hardcodes a minimum k8s version. This makes it impossible to install the helm chart on a cluster running an unsupported k8s version.

The [Flux Installation](https://fluxcd.io/flux/installation/) docs say that Flux may work on older versions, but no support will be provided. Given this, the chart is in my opinion too restrictive. This change is backwards compatible (the value defaults to `true`) but allows the helm chart to be used with older version of Kubernetes.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
