### PR TITLE
Added an optional pre-upgrade helm hook job to flux2 chart

### DIFF
--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.7.5"
+    - "[Feature]: Added an optional pre-upgrade helm hook job, which runs flux migrate to migrate the Flux Custom Resources to their latest API versions."
 apiVersion: v2
 appVersion: 2.7.5
 description: A Helm chart for flux2
@@ -8,4 +8,4 @@ name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.17.2
+version: 2.17.3

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.17.3](https://img.shields.io/badge/Version-2.17.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.5](https://img.shields.io/badge/AppVersion-2.7.5-informational?style=flat-square)
+![Version: 2.17.3](https://img.shields.io/badge/Version-2.17.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.5](https://img.shields.io/badge/AppVersion-2.7.5-informational?style=flat-square)
 
 A Helm chart for flux2
 

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.17.2](https://img.shields.io/badge/Version-2.17.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.5](https://img.shields.io/badge/AppVersion-2.7.5-informational?style=flat-square)
+![Version: 2.17.3](https://img.shields.io/badge/Version-2.17.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.7.5](https://img.shields.io/badge/AppVersion-2.7.5-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -23,6 +23,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
+| crds.migration | object | `{"affinity":{},"annotations":{},"enabled":false,"nodeSelector":{},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"64Mi"}},"tolerations":[]}` | Enable Flux CRs migration using helm pre upgrade hook job |
 | distro.openshift | bool | `false` |  |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmController.affinity | object | `{}` |  |

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -23,7 +23,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
-| crds.migration | object | `{"affinity":{},"annotations":{},"enabled":false,"nodeSelector":{},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"64Mi"}},"tolerations":[]}` | Enable Flux CRs migration using helm pre upgrade hook job |
+| crds.migration | object | `{"affinity":{},"annotations":{},"enabled":false,"nodeSelector":{},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"64Mi"}},"timeout":"5m","tolerations":[]}` | Enable Flux CRs migration using helm pre upgrade hook job |
 | distro.openshift | bool | `false` |  |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmController.affinity | object | `{}` |  |

--- a/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
+++ b/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.crds.migration.enabled -}}
+{{- if and .Values.rbac.create .Values.multitenancy.enabled (not .Values.multitenancy.privileged) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-flux-migrate
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions/status
+    verbs:
+    - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-flux-migrate
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-flux-migrate
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: {{ .Release.Namespace }}
+---
+{{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-flux-migrate"
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      {{- with .Values.crds.migration.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+        app.kubernetes.io/part-of: flux
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: "kustomize-controller"
+      containers:
+      - name: flux-cli-migrate
+        image: {{ template "template.image" .Values.cli }}
+        command: ["/usr/local/bin/flux", "migrate"]
+        {{- with .Values.crds.migration.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.crds.migration.securityContext }}
+        securityContext: {{ toYaml .Values.crds.migration.securityContext | nindent 10 }}
+        {{- else }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          {{- if not .Values.distro.openshift }}
+          runAsUser: 65534
+          {{- end}}
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        {{- end}}
+        {{- if .Values.crds.migration.volumeMounts }}
+        volumeMounts:
+        {{- toYaml .Values.crds.migration.volumeMounts | nindent 10 }}
+        {{- end}}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
+      {{- with .Values.crds.migration.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.crds.migration.volumes }}
+      volumes:
+      {{- toYaml .Values.crds.migration.volumes | nindent 8 }}
+      {{- end}}
+      {{- with .Values.crds.migration.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crds.migration.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
+++ b/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
@@ -87,7 +87,7 @@ spec:
       containers:
       - name: flux-cli-migrate
         image: {{ template "template.image" .Values.cli }}
-        command: ["/usr/local/bin/flux", "migrate"]
+        command: ["/usr/local/bin/flux", "migrate", "--timeout={{ .Values.crds.migration.timeout }}"]
         {{- with .Values.crds.migration.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
         control-plane: controller
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
         control-plane: controller
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
         control-plane: controller
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
         control-plane: controller
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
         control-plane: controller
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -12,7 +12,7 @@ should match snapshot of default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -23,7 +23,7 @@ should match snapshot of default values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
             app.kubernetes.io/version: 2.7.5
-            helm.sh/chart: flux2-2.17.2
+            helm.sh/chart: flux2-2.17.3
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true

--- a/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
@@ -1,0 +1,51 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      annotations:
+        helm.sh/hook: pre-upgrade
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+        helm.sh/hook-weight: "-5"
+      labels:
+        app.kubernetes.io/instance: NAMESPACE
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: flux
+        app.kubernetes.io/version: 2.7.2
+        helm.sh/chart: flux2-2.17.2
+      name: RELEASE-NAME-flux-migrate
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: NAMESPACE
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/part-of: flux
+            app.kubernetes.io/version: 2.7.2
+            helm.sh/chart: flux2-2.17.2
+          name: RELEASE-NAME
+        spec:
+          containers:
+            - command:
+                - /usr/local/bin/flux
+                - migrate
+              image: ghcr.io/fluxcd/flux-cli:v2.7.2
+              name: flux-cli-migrate
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65534
+                seccompProfile:
+                  type: RuntimeDefault
+          restartPolicy: Never
+          serviceAccountName: kustomize-controller

--- a/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
@@ -30,6 +30,7 @@ should match snapshot of default values:
             - command:
                 - /usr/local/bin/flux
                 - migrate
+                - --timeout=5m
               image: ghcr.io/fluxcd/flux-cli:v2.7.2
               name: flux-cli-migrate
               resources:

--- a/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.7.2
-        helm.sh/chart: flux2-2.17.2
+        app.kubernetes.io/version: 2.7.5
+        helm.sh/chart: flux2-2.17.3
       name: RELEASE-NAME-flux-migrate
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.7.2
-            helm.sh/chart: flux2-2.17.2
+            app.kubernetes.io/version: 2.7.5
+            helm.sh/chart: flux2-2.17.3
           name: RELEASE-NAME
         spec:
           containers:
@@ -31,7 +31,7 @@ should match snapshot of default values:
                 - /usr/local/bin/flux
                 - migrate
                 - --timeout=5m
-              image: ghcr.io/fluxcd/flux-cli:v2.7.2
+              image: ghcr.io/fluxcd/flux-cli:v2.7.5
               name: flux-cli-migrate
               resources:
                 limits: {}

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
         control-plane: controller
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot with default values when enabled:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.7.5
         control-plane: controller
-        helm.sh/chart: flux2-2.17.2
+        helm.sh/chart: flux2-2.17.3
       name: source-watcher
     spec:
       replicas: 1

--- a/charts/flux2/tests/pre-upgrade-migrate-resources_test.yaml
+++ b/charts/flux2/tests/pre-upgrade-migrate-resources_test.yaml
@@ -1,0 +1,36 @@
+suite: test pre-upgrade-migrate-resources job hook
+templates:
+  - pre-upgrade-migrate-resources.yaml
+tests:
+  - it: should match snapshot of default values
+    set:
+      crds:
+        migration:
+          enabled: true
+    asserts:
+      - matchSnapshot: {}
+  - it: should set resource requests and limits
+    set:
+      crds:
+        migration:
+          enabled: true      
+          resources:
+            limits:
+              cpu: 300m
+              memory: 1024Mi
+            requests:
+              cpu: 300m
+              memory: 1024Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 300m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1024Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 300m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1024Mi

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -4,6 +4,20 @@ installCRDs: true
 crds:
   # -- Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep
   annotations: {}
+  # -- Enable Flux CRs migration using helm pre upgrade hook job
+  migration:
+    enabled: false
+    resources:
+      limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 64Mi
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    annotations: {}
 
 multitenancy:
   # -- Implement the patches for Multi-tenancy lockdown.

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -7,6 +7,7 @@ crds:
   # -- Enable Flux CRs migration using helm pre upgrade hook job
   migration:
     enabled: false
+    timeout: 5m
     resources:
       limits: {}
       # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

-  Adds a pre-upgrade helm hook job, which runs `flux migrate` to migrate the Flux Custom Resources to their latest API versions. the hook is disabled by default, can be enabled by value settings `crds.migration.enabled` to `true`.



#### Which issue this PR fixes

#### Special notes for your reviewer:

- I've tested the pre-upgrade hook job by deploying the chart locally, with `--set crds.migration.enabled=true` and verified that it renders as expected and successful job completion on multitenancy enabled and privileged disabled setup. the migrate job uses the `kustomize-controller` serviceaccount, which has `cluster-admin` clusterrole binded, with chart default values.  In case of multitenancy enabled and privileged disabled setup, additional rbac access for get, list and update on CRD resource are granted.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
