### PR TITLE
chore: upgrade charts to Flux v2.8.3 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.8.2
+FLUX2_VERSION ?= v2.8.3
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.19.3
-appVersion: 2.8.2
+version: 1.19.4
+appVersion: 2.8.3
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.2"
+    - "[Chore]: Update App Version to upstream 2.8.3"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.19.3](https://img.shields.io/badge/Version-1.19.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 1.19.4](https://img.shields.io/badge/Version-1.19.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
-        helm.sh/chart: flux2-notification-1.19.3
+        app.kubernetes.io/version: 2.8.3
+        helm.sh/chart: flux2-notification-1.19.4
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
-        helm.sh/chart: flux2-notification-1.19.3
+        app.kubernetes.io/version: 2.8.3
+        helm.sh/chart: flux2-notification-1.19.4
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
-        helm.sh/chart: flux2-notification-1.19.3
+        app.kubernetes.io/version: 2.8.3
+        helm.sh/chart: flux2-notification-1.19.4
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.14.3
-appVersion: 2.8.2
+version: 1.14.4
+appVersion: 2.8.3
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.2"
+    - "[Chore]: Update App Version to upstream 2.8.3"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.14.3](https://img.shields.io/badge/Version-1.14.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 1.14.4](https://img.shields.io/badge/Version-1.14.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.8.2"` |  |
+| cli.tag | string | `"v2.8.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.3
+        helm.sh/chart: flux2-sync-1.14.4
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.3
+        helm.sh/chart: flux2-sync-1.14.4
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.3
+        helm.sh/chart: flux2-sync-1.14.4
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.3
+        helm.sh/chart: flux2-sync-1.14.4
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -18,7 +18,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.8.2
+  tag: v2.8.3
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.2"
+    - "[Chore]: Update App Version to upstream 2.8.3"
 apiVersion: v2
-appVersion: 2.8.2
+appVersion: 2.8.3
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.18.1
+version: 2.18.2

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.18.1](https://img.shields.io/badge/Version-2.18.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.2](https://img.shields.io/badge/AppVersion-2.8.2-informational?style=flat-square)
+![Version: 2.18.2](https://img.shields.io/badge/Version-2.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.8.2"` |  |
+| cli.tag | string | `"v2.8.3"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
@@ -42,7 +42,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | helmController.serviceAccount.annotations | object | `{}` |  |
 | helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
-| helmController.tag | string | `"v1.5.2"` |  |
+| helmController.tag | string | `"v1.5.3"` |  |
 | helmController.tolerations | list | `[]` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 2.8.3
         control-plane: controller
-        helm.sh/chart: flux2-2.18.1
+        helm.sh/chart: flux2-2.18.2
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/helm-controller:v1.5.2
+              image: ghcr.io/fluxcd/helm-controller:v1.5.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 2.8.3
         control-plane: controller
-        helm.sh/chart: flux2-2.18.1
+        helm.sh/chart: flux2-2.18.2
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 2.8.3
         control-plane: controller
-        helm.sh/chart: flux2-2.18.1
+        helm.sh/chart: flux2-2.18.2
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
-        helm.sh/chart: flux2-2.18.1
+        app.kubernetes.io/version: 2.8.3
+        helm.sh/chart: flux2-2.18.2
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 2.8.3
         control-plane: controller
-        helm.sh/chart: flux2-2.18.1
+        helm.sh/chart: flux2-2.18.2
       name: kustomize-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 2.8.3
         control-plane: controller
-        helm.sh/chart: flux2-2.18.1
+        helm.sh/chart: flux2-2.18.2
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
-        helm.sh/chart: flux2-2.18.1
+        app.kubernetes.io/version: 2.8.3
+        helm.sh/chart: flux2-2.18.2
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.8.2
-            helm.sh/chart: flux2-2.18.1
+            app.kubernetes.io/version: 2.8.3
+            helm.sh/chart: flux2-2.18.2
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --pre
                 - --namespace
                 - NAMESPACE
-              image: ghcr.io/fluxcd/flux-cli:v2.8.2
+              image: ghcr.io/fluxcd/flux-cli:v2.8.3
               name: flux-cli
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 2.8.3
         control-plane: controller
-        helm.sh/chart: flux2-2.18.1
+        helm.sh/chart: flux2-2.18.2
       name: source-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot with default values when enabled:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 2.8.3
         control-plane: controller
-        helm.sh/chart: flux2-2.18.1
+        helm.sh/chart: flux2-2.18.2
       name: source-watcher
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -23,7 +23,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.8.2
+  tag: v2.8.3
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -36,7 +36,7 @@ cli:
 helmController:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v1.5.2
+  tag: v1.5.3
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgrade to the current flux release

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`

### Chart [ flux2-multi-tenancy ] charts/flux2-multi-tenancy/

 PASS  test kyverno deployment  charts/flux2-multi-tenancy/tests/kyverno-policy_test.yaml
 PASS  test kyverno deployment  charts/flux2-multi-tenancy/tests/kyverno-policy_test.yaml

Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshot:    2 passed, 2 total
Time:        6.728125ms


### Chart [ flux2 ] charts/flux2/

 PASS  test cluster reconciler  charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrole_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrolebinding.yaml
 PASS  test extra-manifests deployment  charts/flux2/tests/extra-manifests_test.yaml
 PASS  test helm-controller deployment  charts/flux2/tests/helm-controller_test.yaml
 PASS  test image-automation-controller deployment      charts/flux2/tests/image-automation-controller_test.yaml
 PASS  test image-reflector-controller deployment       charts/flux2/tests/image-reflector-controller_test.yaml
 PASS  test kustomize-controller-secret deployment      charts/flux2/tests/kustomize-controller-secret_test.yaml
 PASS  test kustomize-controller deployment     charts/flux2/tests/kustomize-controller_test.yaml
 PASS  test notification-controller deployment  charts/flux2/tests/notification-controller_test.yaml
 PASS  test pre-install-job hook        charts/flux2/tests/pre-install-job_test.yaml
 PASS  test source-controller deployment        charts/flux2/tests/source-controller_test.yaml
 PASS  test source-watcher deployment   charts/flux2/tests/source-watcher.yaml
 PASS  test cluster reconciler  charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrole_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrolebinding.yaml
 PASS  test extra-manifests deployment  charts/flux2/tests/extra-manifests_test.yaml
 PASS  test helm-controller deployment  charts/flux2/tests/helm-controller_test.yaml
 PASS  test image-automation-controller deployment      charts/flux2/tests/image-automation-controller_test.yaml
 PASS  test image-reflector-controller deployment       charts/flux2/tests/image-reflector-controller_test.yaml
 PASS  test kustomize-controller-secret deployment      charts/flux2/tests/kustomize-controller-secret_test.yaml
 PASS  test kustomize-controller deployment     charts/flux2/tests/kustomize-controller_test.yaml
 PASS  test notification-controller deployment  charts/flux2/tests/notification-controller_test.yaml
 PASS  test pre-install-job hook        charts/flux2/tests/pre-install-job_test.yaml
 PASS  test source-controller deployment        charts/flux2/tests/source-controller_test.yaml
 PASS  test source-watcher deployment   charts/flux2/tests/source-watcher.yaml

Charts:      1 passed, 1 total
Test Suites: 26 passed, 26 total
Tests:       218 passed, 218 total
Snapshot:    18 passed, 18 total
Time:        185.486834ms


### Chart [ flux2-sync ] charts/flux2-sync/

 PASS  test flux-gitrepository  charts/flux2-sync/tests/flux-gitrepository_test.yaml
 PASS  test flux-kustomization  charts/flux2-sync/tests/flux-kustomization_test.yaml
 PASS  test secret deployment   charts/flux2-sync/tests/secret_test.yaml
 PASS  test flux-gitrepository  charts/flux2-sync/tests/flux-gitrepository_test.yaml
 PASS  test flux-kustomization  charts/flux2-sync/tests/flux-kustomization_test.yaml
 PASS  test secret deployment   charts/flux2-sync/tests/secret_test.yaml

Charts:      1 passed, 1 total
Test Suites: 6 passed, 6 total
Tests:       12 passed, 12 total
Snapshot:    8 passed, 8 total
Time:        8.017959ms


### Chart [ flux2-notification ] charts/flux2-notification/

 PASS  test alert deployment    charts/flux2-notification/tests/alert_test.yaml
 PASS  test provider deployment charts/flux2-notification/tests/provider_test.yaml
 PASS  test secret deployment   charts/flux2-notification/tests/secret_test.yaml
 PASS  test alert deployment    charts/flux2-notification/tests/alert_test.yaml
 PASS  test provider deployment charts/flux2-notification/tests/provider_test.yaml
 PASS  test secret deployment   charts/flux2-notification/tests/secret_test.yaml

Charts:      1 passed, 1 total
Test Suites: 6 passed, 6 total
Tests:       14 passed, 14 total
Snapshot:    6 passed, 6 total
Time:        6.065917ms

09:49:57 [ .. ] checking that branch is clean
09:49:57 [ OK ] branch is clean