### PR TITLE
chore: upgrade charts to Flux v2.8.5 release (adds `flux migrate` pre-upgrade hook)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.8.3
+FLUX2_VERSION ?= v2.8.5
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.19.4
-appVersion: 2.8.3
+version: 1.19.5
+appVersion: 2.8.5
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.3"
+    - "[Chore]: Update App Version to upstream 2.8.5"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.19.4](https://img.shields.io/badge/Version-1.19.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
+![Version: 1.19.5](https://img.shields.io/badge/Version-1.19.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.5](https://img.shields.io/badge/AppVersion-2.8.5-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
-        helm.sh/chart: flux2-notification-1.19.4
+        app.kubernetes.io/version: 2.8.5
+        helm.sh/chart: flux2-notification-1.19.5
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
-        helm.sh/chart: flux2-notification-1.19.4
+        app.kubernetes.io/version: 2.8.5
+        helm.sh/chart: flux2-notification-1.19.5
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
-        helm.sh/chart: flux2-notification-1.19.4
+        app.kubernetes.io/version: 2.8.5
+        helm.sh/chart: flux2-notification-1.19.5
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.14.4
-appVersion: 2.8.3
+version: 1.14.5
+appVersion: 2.8.5
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.3"
+    - "[Chore]: Update App Version to upstream 2.8.5"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.14.4](https://img.shields.io/badge/Version-1.14.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
+![Version: 1.14.5](https://img.shields.io/badge/Version-1.14.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.5](https://img.shields.io/badge/AppVersion-2.8.5-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.8.3"` |  |
+| cli.tag | string | `"v2.8.5"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.4
+        helm.sh/chart: flux2-sync-1.14.5
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.4
+        helm.sh/chart: flux2-sync-1.14.5
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.4
+        helm.sh/chart: flux2-sync-1.14.5
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.4
+        helm.sh/chart: flux2-sync-1.14.5
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -18,7 +18,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.8.3
+  tag: v2.8.5
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,12 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.3"
+    - "[Chore]: Update App Version to upstream 2.8.5"
+    - "[Feature]: Added an optional pre-upgrade helm hook job, which runs flux migrate to migrate the Flux Custom Resources to their latest API versions."
 apiVersion: v2
-appVersion: 2.8.3
+appVersion: 2.8.5
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.18.2
+version: 2.18.3

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.18.2](https://img.shields.io/badge/Version-2.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.3](https://img.shields.io/badge/AppVersion-2.8.3-informational?style=flat-square)
+![Version: 2.18.3](https://img.shields.io/badge/Version-2.18.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.5](https://img.shields.io/badge/AppVersion-2.8.5-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,10 +19,11 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.8.3"` |  |
+| cli.tag | string | `"v2.8.5"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
+| crds.migration | object | `{"affinity":{},"annotations":{},"enabled":false,"nodeSelector":{},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"64Mi"}},"timeout":"5m","tolerations":[]}` | Enable Flux CRs migration using helm pre upgrade hook job |
 | distro.openshift | bool | `false` |  |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy |
 | helmController.affinity | object | `{}` |  |
@@ -106,7 +107,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.8.2"` |  |
+| kustomizeController.tag | string | `"v1.8.3"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -131,7 +132,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | notificationController.serviceAccount.annotations | object | `{}` |  |
 | notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
-| notificationController.tag | string | `"v1.8.2"` |  |
+| notificationController.tag | string | `"v1.8.3"` |  |
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.ingress.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.ingress.create | bool | `false` |  |
@@ -171,7 +172,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.8.1"` |  |
+| sourceController.tag | string | `"v1.8.2"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | sourceWatcher.affinity | object | `{}` |  |
 | sourceWatcher.annotations."prometheus.io/port" | string | `"8080"` |  |

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -956,7 +956,11 @@ spec:
               secretRef:
                 description: |-
                   SecretRef specifies the Secret containing the token used
-                  to validate the payload authenticity.
+                  to validate the payload authenticity. The Secret must contain a 'token'
+                  key. For GCR receivers, the Secret must also contain an 'email' key
+                  with the IAM service account email configured on the Pub/Sub push
+                  subscription, and may optionally contain an 'audience' key with the
+                  expected OIDC token audience.
                 properties:
                   name:
                     description: Name of the referent.

--- a/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
+++ b/charts/flux2/templates/pre-upgrade-migrate-resources.yaml
@@ -1,0 +1,130 @@
+{{- if .Values.crds.migration.enabled -}}
+{{- if and .Values.rbac.create .Values.multitenancy.enabled (not .Values.multitenancy.privileged) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-flux-migrate
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions/status
+    verbs:
+    - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-flux-migrate
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+    helm.sh/hook-weight: "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-flux-migrate
+subjects:
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: {{ .Release.Namespace }}
+---
+{{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-flux-migrate"
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+    app.kubernetes.io/part-of: flux
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      {{- with .Values.crds.migration.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Namespace | quote }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion | quote  }}
+        app.kubernetes.io/part-of: flux
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: "kustomize-controller"
+      containers:
+      - name: flux-cli-migrate
+        image: {{ template "template.image" .Values.cli }}
+        command: ["/usr/local/bin/flux", "migrate", "--timeout={{ .Values.crds.migration.timeout }}"]
+        {{- with .Values.crds.migration.resources }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.crds.migration.securityContext }}
+        securityContext: {{ toYaml .Values.crds.migration.securityContext | nindent 10 }}
+        {{- else }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          {{- if not .Values.distro.openshift }}
+          runAsUser: 65534
+          {{- end}}
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        {{- end}}
+        {{- if .Values.crds.migration.volumeMounts }}
+        volumeMounts:
+        {{- toYaml .Values.crds.migration.volumeMounts | nindent 10 }}
+        {{- end}}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 6 }}
+      {{- end }}
+      {{- with .Values.crds.migration.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.crds.migration.volumes }}
+      volumes:
+      {{- toYaml .Values.crds.migration.volumes | nindent 8 }}
+      {{- end}}
+      {{- with .Values.crds.migration.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.crds.migration.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
+        app.kubernetes.io/version: 2.8.5
         control-plane: controller
-        helm.sh/chart: flux2-2.18.2
+        helm.sh/chart: flux2-2.18.3
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
+        app.kubernetes.io/version: 2.8.5
         control-plane: controller
-        helm.sh/chart: flux2-2.18.2
+        helm.sh/chart: flux2-2.18.3
       name: image-automation-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
+        app.kubernetes.io/version: 2.8.5
         control-plane: controller
-        helm.sh/chart: flux2-2.18.2
+        helm.sh/chart: flux2-2.18.3
       name: image-reflector-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
-        helm.sh/chart: flux2-2.18.2
+        app.kubernetes.io/version: 2.8.5
+        helm.sh/chart: flux2-2.18.3
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
+        app.kubernetes.io/version: 2.8.5
         control-plane: controller
-        helm.sh/chart: flux2-2.18.2
+        helm.sh/chart: flux2-2.18.3
       name: kustomize-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/kustomize-controller:v1.8.2
+              image: ghcr.io/fluxcd/kustomize-controller:v1.8.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
+        app.kubernetes.io/version: 2.8.5
         control-plane: controller
-        helm.sh/chart: flux2-2.18.2
+        helm.sh/chart: flux2-2.18.3
       name: notification-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/notification-controller:v1.8.2
+              image: ghcr.io/fluxcd/notification-controller:v1.8.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
@@ -4,7 +4,7 @@ should match snapshot of default values:
     kind: Job
     metadata:
       annotations:
-        helm.sh/hook: pre-install
+        helm.sh/hook: pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
         helm.sh/hook-weight: "-5"
       labels:
@@ -13,7 +13,7 @@ should match snapshot of default values:
         app.kubernetes.io/part-of: flux
         app.kubernetes.io/version: 2.8.5
         helm.sh/chart: flux2-2.18.3
-      name: RELEASE-NAME-flux-check
+      name: RELEASE-NAME-flux-migrate
     spec:
       backoffLimit: 1
       template:
@@ -26,16 +26,18 @@ should match snapshot of default values:
             helm.sh/chart: flux2-2.18.3
           name: RELEASE-NAME
         spec:
-          automountServiceAccountToken: true
           containers:
             - command:
                 - /usr/local/bin/flux
-                - check
-                - --pre
-                - --namespace
-                - NAMESPACE
+                - migrate
+                - --timeout=5m
               image: ghcr.io/fluxcd/flux-cli:v2.8.5
-              name: flux-cli
+              name: flux-cli-migrate
+              resources:
+                limits: {}
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
@@ -47,4 +49,4 @@ should match snapshot of default values:
                 seccompProfile:
                   type: RuntimeDefault
           restartPolicy: Never
-          serviceAccountName: RELEASE-NAME-flux-check
+          serviceAccountName: kustomize-controller

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
+        app.kubernetes.io/version: 2.8.5
         control-plane: controller
-        helm.sh/chart: flux2-2.18.2
+        helm.sh/chart: flux2-2.18.3
       name: source-controller
     spec:
       replicas: 1
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/source-controller:v1.8.1
+              image: ghcr.io/fluxcd/source-controller:v1.8.2
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot with default values when enabled:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.3
+        app.kubernetes.io/version: 2.8.5
         control-plane: controller
-        helm.sh/chart: flux2-2.18.2
+        helm.sh/chart: flux2-2.18.3
       name: source-watcher
     spec:
       replicas: 1

--- a/charts/flux2/tests/pre-upgrade-migrate-resources_test.yaml
+++ b/charts/flux2/tests/pre-upgrade-migrate-resources_test.yaml
@@ -1,0 +1,36 @@
+suite: test pre-upgrade-migrate-resources job hook
+templates:
+  - pre-upgrade-migrate-resources.yaml
+tests:
+  - it: should match snapshot of default values
+    set:
+      crds:
+        migration:
+          enabled: true
+    asserts:
+      - matchSnapshot: {}
+  - it: should set resource requests and limits
+    set:
+      crds:
+        migration:
+          enabled: true      
+          resources:
+            limits:
+              cpu: 300m
+              memory: 1024Mi
+            requests:
+              cpu: 300m
+              memory: 1024Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 300m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1024Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 300m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1024Mi

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -4,6 +4,21 @@ installCRDs: true
 crds:
   # -- Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep
   annotations: {}
+  # -- Enable Flux CRs migration using helm pre upgrade hook job
+  migration:
+    enabled: false
+    timeout: 5m
+    resources:
+      limits: {}
+      # cpu: 1000m
+      # memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 64Mi
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    annotations: {}
 
 multitenancy:
   # -- Implement the patches for Multi-tenancy lockdown.
@@ -23,7 +38,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.8.3
+  tag: v2.8.5
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -140,7 +155,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.8.2
+  tag: v1.8.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -188,7 +203,7 @@ kustomizeController:
 notificationController:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v1.8.2
+  tag: v1.8.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -241,7 +256,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.8.1
+  tag: v1.8.2
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

- Upgrades the helm charts to use the [Flux2 v2.8.5](https://github.com/fluxcd/flux2/releases/tag/v2.8.5) patch release.
- Adds a pre-upgrade helm hook job, which runs `flux migrate` to migrate the Flux Custom Resources to their latest API versions. the hook is disabled by default, can be enabled by value settings `crds.migration.enabled` to `true`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`
