### PR TITLE
chore: upgrade charts to Flux v2.8.8 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.8.5
+FLUX2_VERSION ?= v2.8.8
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.19.5
-appVersion: 2.8.5
+version: 1.19.6
+appVersion: 2.8.8
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.5"
+    - "[Chore]: Update App Version to upstream 2.8.8"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.19.5](https://img.shields.io/badge/Version-1.19.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.5](https://img.shields.io/badge/AppVersion-2.8.5-informational?style=flat-square)
+![Version: 1.19.6](https://img.shields.io/badge/Version-1.19.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.8](https://img.shields.io/badge/AppVersion-2.8.8-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
-        helm.sh/chart: flux2-notification-1.19.5
+        app.kubernetes.io/version: 2.8.8
+        helm.sh/chart: flux2-notification-1.19.6
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
-        helm.sh/chart: flux2-notification-1.19.5
+        app.kubernetes.io/version: 2.8.8
+        helm.sh/chart: flux2-notification-1.19.6
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
-        helm.sh/chart: flux2-notification-1.19.5
+        app.kubernetes.io/version: 2.8.8
+        helm.sh/chart: flux2-notification-1.19.6
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.14.5
-appVersion: 2.8.5
+version: 1.14.6
+appVersion: 2.8.8
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.5"
+    - "[Chore]: Update App Version to upstream 2.8.8"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.14.5](https://img.shields.io/badge/Version-1.14.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.5](https://img.shields.io/badge/AppVersion-2.8.5-informational?style=flat-square)
+![Version: 1.14.6](https://img.shields.io/badge/Version-1.14.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.8](https://img.shields.io/badge/AppVersion-2.8.8-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.8.5"` |  |
+| cli.tag | string | `"v2.8.8"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.5
+        helm.sh/chart: flux2-sync-1.14.6
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.5
+        helm.sh/chart: flux2-sync-1.14.6
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.5
+        helm.sh/chart: flux2-sync-1.14.6
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.14.5
+        helm.sh/chart: flux2-sync-1.14.6
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -18,7 +18,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.8.5
+  tag: v2.8.8
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,12 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.8.5"
-    - "[Feature]: Added an optional pre-upgrade helm hook job, which runs flux migrate to migrate the Flux Custom Resources to their latest API versions."
+    - "[Chore]: Update App Version to upstream 2.8.8"
 apiVersion: v2
-appVersion: 2.8.5
+appVersion: 2.8.8
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.18.3
+version: 2.18.4

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.18.3](https://img.shields.io/badge/Version-2.18.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.5](https://img.shields.io/badge/AppVersion-2.8.5-informational?style=flat-square)
+![Version: 2.18.4](https://img.shields.io/badge/Version-2.18.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.8](https://img.shields.io/badge/AppVersion-2.8.8-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.8.5"` |  |
+| cli.tag | string | `"v2.8.8"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
@@ -43,7 +43,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | helmController.serviceAccount.annotations | object | `{}` |  |
 | helmController.serviceAccount.automount | bool | `true` |  |
 | helmController.serviceAccount.create | bool | `true` |  |
-| helmController.tag | string | `"v1.5.3"` |  |
+| helmController.tag | string | `"v1.5.5"` |  |
 | helmController.tolerations | list | `[]` |  |
 | imageAutomationController.affinity | object | `{}` |  |
 | imageAutomationController.annotations."prometheus.io/port" | string | `"8080"` |  |
@@ -62,7 +62,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
-| imageAutomationController.tag | string | `"v1.1.1"` |  |
+| imageAutomationController.tag | string | `"v1.1.4"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -82,7 +82,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v1.1.1"` |  |
+| imageReflectionController.tag | string | `"v1.1.2"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -107,7 +107,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.8.3"` |  |
+| kustomizeController.tag | string | `"v1.8.5"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -132,7 +132,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | notificationController.serviceAccount.annotations | object | `{}` |  |
 | notificationController.serviceAccount.automount | bool | `true` |  |
 | notificationController.serviceAccount.create | bool | `true` |  |
-| notificationController.tag | string | `"v1.8.3"` |  |
+| notificationController.tag | string | `"v1.8.4"` |  |
 | notificationController.tolerations | list | `[]` |  |
 | notificationController.webhookReceiver.ingress.annotations | object | `{}` |  |
 | notificationController.webhookReceiver.ingress.create | bool | `false` |  |
@@ -172,7 +172,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.8.2"` |  |
+| sourceController.tag | string | `"v1.8.5"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | sourceWatcher.affinity | object | `{}` |  |
 | sourceWatcher.annotations."prometheus.io/port" | string | `"8080"` |  |

--- a/charts/flux2/templates/helm-controller.crds.yaml
+++ b/charts/flux2/templates/helm-controller.crds.yaml
@@ -766,8 +766,11 @@ spec:
                       rollback has been performed.
                     type: boolean
                   force:
-                    description: Force forces resource updates through a replacement
-                      strategy.
+                    description: |-
+                      Force forces resource updates through a replacement strategy
+                      that avoids 3-way merge conflicts on client-side apply.
+                      This field is ignored for server-side apply (which always
+                      forces conflicts with other field managers).
                     type: boolean
                   recreate:
                     description: |-
@@ -971,8 +974,11 @@ spec:
                       upgrade has been performed.
                     type: boolean
                   force:
-                    description: Force forces resource updates through a replacement
-                      strategy.
+                    description: |-
+                      Force forces resource updates through a replacement strategy
+                      that avoids 3-way merge conflicts on client-side apply.
+                      This field is ignored for server-side apply (which always
+                      forces conflicts with other field managers).
                     type: boolean
                   preserveValues:
                     description: |-

--- a/charts/flux2/templates/notification-controller.crds.yaml
+++ b/charts/flux2/templates/notification-controller.crds.yaml
@@ -959,8 +959,7 @@ spec:
                   to validate the payload authenticity. The Secret must contain a 'token'
                   key. For GCR receivers, the Secret must also contain an 'email' key
                   with the IAM service account email configured on the Pub/Sub push
-                  subscription, and may optionally contain an 'audience' key with the
-                  expected OIDC token audience.
+                  subscription, and an 'audience' key with the expected OIDC token audience.
                 properties:
                   name:
                     description: Name of the referent.

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
+        app.kubernetes.io/version: 2.8.8
         control-plane: controller
-        helm.sh/chart: flux2-2.18.3
+        helm.sh/chart: flux2-2.18.4
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/helm-controller:v1.5.3
+              image: ghcr.io/fluxcd/helm-controller:v1.5.5
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
+        app.kubernetes.io/version: 2.8.8
         control-plane: controller
-        helm.sh/chart: flux2-2.18.3
+        helm.sh/chart: flux2-2.18.4
       name: image-automation-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-automation-controller:v1.1.1
+              image: ghcr.io/fluxcd/image-automation-controller:v1.1.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
+        app.kubernetes.io/version: 2.8.8
         control-plane: controller
-        helm.sh/chart: flux2-2.18.3
+        helm.sh/chart: flux2-2.18.4
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-reflector-controller:v1.1.1
+              image: ghcr.io/fluxcd/image-reflector-controller:v1.1.2
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
-        helm.sh/chart: flux2-2.18.3
+        app.kubernetes.io/version: 2.8.8
+        helm.sh/chart: flux2-2.18.4
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
+        app.kubernetes.io/version: 2.8.8
         control-plane: controller
-        helm.sh/chart: flux2-2.18.3
+        helm.sh/chart: flux2-2.18.4
       name: kustomize-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/kustomize-controller:v1.8.3
+              image: ghcr.io/fluxcd/kustomize-controller:v1.8.5
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
+        app.kubernetes.io/version: 2.8.8
         control-plane: controller
-        helm.sh/chart: flux2-2.18.3
+        helm.sh/chart: flux2-2.18.4
       name: notification-controller
     spec:
       replicas: 1
@@ -37,7 +37,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/notification-controller:v1.8.3
+              image: ghcr.io/fluxcd/notification-controller:v1.8.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
-        helm.sh/chart: flux2-2.18.3
+        app.kubernetes.io/version: 2.8.8
+        helm.sh/chart: flux2-2.18.4
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.8.5
-            helm.sh/chart: flux2-2.18.3
+            app.kubernetes.io/version: 2.8.8
+            helm.sh/chart: flux2-2.18.4
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --pre
                 - --namespace
                 - NAMESPACE
-              image: ghcr.io/fluxcd/flux-cli:v2.8.5
+              image: ghcr.io/fluxcd/flux-cli:v2.8.8
               name: flux-cli
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
-        helm.sh/chart: flux2-2.18.3
+        app.kubernetes.io/version: 2.8.8
+        helm.sh/chart: flux2-2.18.4
       name: RELEASE-NAME-flux-migrate
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.8.5
-            helm.sh/chart: flux2-2.18.3
+            app.kubernetes.io/version: 2.8.8
+            helm.sh/chart: flux2-2.18.4
           name: RELEASE-NAME
         spec:
           containers:
@@ -31,7 +31,7 @@ should match snapshot of default values:
                 - /usr/local/bin/flux
                 - migrate
                 - --timeout=5m
-              image: ghcr.io/fluxcd/flux-cli:v2.8.5
+              image: ghcr.io/fluxcd/flux-cli:v2.8.8
               name: flux-cli-migrate
               resources:
                 limits: {}

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
+        app.kubernetes.io/version: 2.8.8
         control-plane: controller
-        helm.sh/chart: flux2-2.18.3
+        helm.sh/chart: flux2-2.18.4
       name: source-controller
     spec:
       replicas: 1
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/source-controller:v1.8.2
+              image: ghcr.io/fluxcd/source-controller:v1.8.5
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot with default values when enabled:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.8.5
+        app.kubernetes.io/version: 2.8.8
         control-plane: controller
-        helm.sh/chart: flux2-2.18.3
+        helm.sh/chart: flux2-2.18.4
       name: source-watcher
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -38,7 +38,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.8.5
+  tag: v2.8.8
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -51,7 +51,7 @@ cli:
 helmController:
   create: true
   image: ghcr.io/fluxcd/helm-controller
-  tag: v1.5.3
+  tag: v1.5.5
   resources:
     limits: {}
     # cpu: 1000m
@@ -99,7 +99,7 @@ helmController:
 imageAutomationController:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v1.1.1
+  tag: v1.1.4
   resources:
     limits: {}
     # cpu: 1000m
@@ -127,7 +127,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v1.1.1
+  tag: v1.1.2
   resources:
     limits: {}
     # cpu: 1000m
@@ -155,7 +155,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.8.3
+  tag: v1.8.5
   resources:
     limits: {}
     # cpu: 1000m
@@ -203,7 +203,7 @@ kustomizeController:
 notificationController:
   create: true
   image: ghcr.io/fluxcd/notification-controller
-  tag: v1.8.3
+  tag: v1.8.4
   resources:
     limits: {}
     # cpu: 1000m
@@ -256,7 +256,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.8.2
+  tag: v1.8.5
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Upgrades the helm charts to use the [Flux2 v2.8.8](https://github.com/fluxcd/flux2/releases/tag/v2.8.8) patch release.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
