### PR TITLE
feat(flux2-sync): add field kustomization.spec.ignore

### DIFF
--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.15.0
+version: 1.16.0
 appVersion: 2.9.1
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.9.1"
+    - "[Feat]: add field kustomization.spec.ignore"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -53,6 +53,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomization.spec.targetNamespace | string | `""` | _Optional_ TargetNamespace sets or overrides the namespace in the kustomization.yaml file. |
 | kustomization.spec.timeout | string | `""` | _Optional_ Timeout for validation, apply and health checking operations. Defaults to ‘Interval’ duration |
 | kustomization.spec.wait | bool | `false` | _Optional_ Wait instructs the controller to check the health of all the reconciled resources. When enabled, the HealthChecks are ignored. Defaults to false. |
+| kustomization.spec.ignore | list | `[]` | _Optional_ Ignore is a list of (paths, target) to selectively ignore changes to specific fields during drift detection and correction.
 | kustomizationlist | object | `{}` | _Optional_ If you want multiple subdirectories which depend on each other in the same repo. Their name is derived from their path. |
 | secret.create | bool | `false` | Create a secret for the git repository. Defaults to false. |
 | secret.data | object | `{}` | Data of the secret. For HTTPS repositories the secret must contain username and password fields. For SSH repositories the secret must contain identity, identity.pub and known_hosts fields. For GitHub App authentication the secret must contain githubAppID, githubAppInstallationID and githubAppPrivateKey fields. Values will be encoded to base64 by the helm chart. |

--- a/charts/flux2-sync/templates/flux-kustomization.yaml
+++ b/charts/flux2-sync/templates/flux-kustomization.yaml
@@ -67,6 +67,9 @@ spec:
   {{- if .Values.kustomization.spec.deletionPolicy }}
   deletionPolicy: {{ .Values.kustomization.spec.deletionPolicy }}
   {{- end }}
+  {{- if .Values.kustomization.spec.ignore }}
+  ignore: {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- if .Values.kustomizationlist}}
 {{- range $key, $kust := .Values.kustomizationlist }}
@@ -137,6 +140,9 @@ spec:
   {{- end }}
   {{- if $kust.spec.deletionPolicy }}
   deletionPolicy: {{ $kust.spec.deletionPolicy }}
+  {{- end }}
+  {{- if $kust.spec.ignore }}
+  ignore: {{ toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.16.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.16.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.16.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.16.0
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -130,6 +130,9 @@ kustomization:
     # -- _Optional_ DeletionPolicy allows control over garbage collection when a Kustomization object is deleted.
     deletionPolicy: ""
 
+    # -- _Optional_ Ignore is a list used to selectively ignore changes to specific fields during drift detection and correction.
+    ignore: []
+
 # -- _Optional_ If you want multiple subdirectories which depend on each other in the same repo. Their name is derived from their path.
 kustomizationlist: {}
 # - spec:


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR adds IgnoreRules to kustomizations as described in the [documentation](https://fluxcd.io/flux/components/kustomize/kustomizations/#ignore-rules).

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] helm-docs are updated
- [x] Helm chart is tested
- [x] Update artifacthub.io/changes in Chart.yaml
- [x] Run `make reviewable`
