### PR TITLE
fix(ci): generate release notes for chart releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ jobs:
           version: 3.10.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,3 @@
+# chart-releaser config, used by .github/workflows/release.yml
+# Appends GitHub's auto-generated release notes to the release body.
+generate-release-notes: true


### PR DESCRIPTION
Chart releases on GitHub currently have no release notes, the body is just the chart description ("A Helm chart for flux2"). 
Because of that, tools like Renovate and Dependabot have nothing to show in their update PRs, so there's no way to see what actually changed without digging through commits.

This enables chart-releaser's `generate-release-notes` option via a `cr.yaml` config file, so GitHub appends its auto-generated notes (the commit/PR list since the previous release) to each release body. 
Those entries include the "update charts to upstream version x.y.z" PRs, which link through to the actual changes.

The chart-releaser-action bump from `v1.2.1` to `v1.7.0` is needed because `generate-release-notes` requires chart-releaser `1.6.0` or newer.

One caveat: when multiple charts are released from the same commit, only the first tag gets a meaningful diff. 
The others compare against a tag pointing at that same commit and end up with an empty list. Charts are processed alphabetically, so `flux2` always gets proper notes.