### PR TITLE
chore: update charts to upstream version 2.9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-FLUX2_VERSION ?= v2.9.1
+FLUX2_VERSION ?= v2.9.2
 
 # set the shell to bash always
 SHELL := /bin/bash

--- a/charts/flux2-notification/Chart.yaml
+++ b/charts/flux2-notification/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-notification
 type: application
-version: 1.20.0
-appVersion: 2.9.1
+version: 1.20.1
+appVersion: 2.9.2
 description: A Helm chart for flux2 alerts and the needed providers and secrets
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.9.1"
+    - "[Chore]: Update App Version to upstream 2.9.2"

--- a/charts/flux2-notification/README.md
+++ b/charts/flux2-notification/README.md
@@ -1,6 +1,6 @@
 # flux2-notification
 
-![Version: 1.20.0](https://img.shields.io/badge/Version-1.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 1.20.1](https://img.shields.io/badge/Version-1.20.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 A Helm chart for flux2 alerts and the needed providers and secrets
 

--- a/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/alert_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
-        helm.sh/chart: flux2-notification-1.20.0
+        app.kubernetes.io/version: 2.9.2
+        helm.sh/chart: flux2-notification-1.20.1
       name: all-kustomizations
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/provider_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
-        helm.sh/chart: flux2-notification-1.20.0
+        app.kubernetes.io/version: 2.9.2
+        helm.sh/chart: flux2-notification-1.20.1
       name: on-call-slack
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-notification/tests/__snapshot__/secret_test.yaml.snap
@@ -7,8 +7,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
-        helm.sh/chart: flux2-notification-1.20.0
+        app.kubernetes.io/version: 2.9.2
+        helm.sh/chart: flux2-notification-1.20.1
       name: webhook-url
       namespace: NAMESPACE
     stringData:

--- a/charts/flux2-sync/Chart.yaml
+++ b/charts/flux2-sync/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: flux2-sync
 type: application
-version: 1.15.0
-appVersion: 2.9.1
+version: 1.15.1
+appVersion: 2.9.2
 description: A Helm chart for flux2 GitRepository to sync with
 sources:
   - https://github.com/fluxcd-community/helm-charts
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.9.1"
+    - "[Chore]: Update App Version to upstream 2.9.2"

--- a/charts/flux2-sync/README.md
+++ b/charts/flux2-sync/README.md
@@ -1,6 +1,6 @@
 # flux2-sync
 
-![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 1.15.1](https://img.shields.io/badge/Version-1.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 A Helm chart for flux2 GitRepository to sync with
 
@@ -17,7 +17,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.affinity | object | `{}` |  |
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
-| cli.tag | string | `"v2.9.1"` |  |
+| cli.tag | string | `"v2.9.2"` |  |
 | cli.tolerations | list | `[]` |  |
 | gitRepository.annotations | object | `{}` |  |
 | gitRepository.labels | object | `{}` |  |

--- a/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-gitrepository_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.15.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -24,7 +24,7 @@ should match snapshot with special values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.15.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/flux-kustomization_test.yaml.snap
@@ -7,7 +7,7 @@ should match kubeconfig:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.15.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/flux2-sync/tests/__snapshot__/secret_test.yaml.snap
@@ -10,7 +10,7 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        helm.sh/chart: flux2-sync-1.15.0
+        helm.sh/chart: flux2-sync-1.15.1
       name: RELEASE-NAME
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2-sync/values.yaml
+++ b/charts/flux2-sync/values.yaml
@@ -18,7 +18,7 @@ secret:
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.9.1
+  tag: v2.9.2
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/charts/flux2/Chart.yaml
+++ b/charts/flux2/Chart.yaml
@@ -1,11 +1,11 @@
 annotations:
   artifacthub.io/changes: |
-    - "[Chore]: Update App Version to upstream 2.9.1"
+    - "[Chore]: Update App Version to upstream 2.9.2"
 apiVersion: v2
-appVersion: 2.9.1
+appVersion: 2.9.2
 description: A Helm chart for flux2
 name: flux2
 sources:
 - https://github.com/fluxcd-community/helm-charts
 type: application
-version: 2.19.0
+version: 2.19.1

--- a/charts/flux2/README.md
+++ b/charts/flux2/README.md
@@ -1,6 +1,6 @@
 # flux2
 
-![Version: 2.19.0](https://img.shields.io/badge/Version-2.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.1](https://img.shields.io/badge/AppVersion-2.9.1-informational?style=flat-square)
+![Version: 2.19.1](https://img.shields.io/badge/Version-2.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.9.2](https://img.shields.io/badge/AppVersion-2.9.2-informational?style=flat-square)
 
 A Helm chart for flux2
 
@@ -19,7 +19,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | cli.image | string | `"ghcr.io/fluxcd/flux-cli"` |  |
 | cli.nodeSelector | object | `{}` |  |
 | cli.serviceAccount.automount | bool | `true` |  |
-| cli.tag | string | `"v2.9.1"` |  |
+| cli.tag | string | `"v2.9.2"` |  |
 | cli.tolerations | list | `[]` |  |
 | clusterDomain | string | `"cluster.local"` |  |
 | crds.annotations | object | `{}` | Add annotations to all CRD resources, e.g. "helm.sh/resource-policy": keep |
@@ -62,7 +62,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageAutomationController.serviceAccount.annotations | object | `{}` |  |
 | imageAutomationController.serviceAccount.automount | bool | `true` |  |
 | imageAutomationController.serviceAccount.create | bool | `true` |  |
-| imageAutomationController.tag | string | `"v1.2.2"` |  |
+| imageAutomationController.tag | string | `"v1.2.3"` |  |
 | imageAutomationController.tolerations | list | `[]` |  |
 | imagePullSecrets | list | `[]` | contents of pod imagePullSecret in form 'name=[secretName]'; applied to all controllers |
 | imageReflectionController.affinity | object | `{}` |  |
@@ -82,7 +82,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | imageReflectionController.serviceAccount.annotations | object | `{}` |  |
 | imageReflectionController.serviceAccount.automount | bool | `true` |  |
 | imageReflectionController.serviceAccount.create | bool | `true` |  |
-| imageReflectionController.tag | string | `"v1.2.2"` |  |
+| imageReflectionController.tag | string | `"v1.2.3"` |  |
 | imageReflectionController.tolerations | list | `[]` |  |
 | installCRDs | bool | `true` |  |
 | kustomizeController.affinity | object | `{}` |  |
@@ -107,7 +107,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | kustomizeController.serviceAccount.annotations | object | `{}` |  |
 | kustomizeController.serviceAccount.automount | bool | `true` |  |
 | kustomizeController.serviceAccount.create | bool | `true` |  |
-| kustomizeController.tag | string | `"v1.9.2"` |  |
+| kustomizeController.tag | string | `"v1.9.3"` |  |
 | kustomizeController.tolerations | list | `[]` |  |
 | logLevel | string | `"info"` |  |
 | multitenancy.defaultServiceAccount | string | `"default"` | All Kustomizations and HelmReleases which don’t have spec.serviceAccountName specified, will use the default account from the tenant’s namespace. Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the default account has no permissions. |
@@ -172,7 +172,7 @@ This helm chart is maintained and released by the fluxcd-community on a best eff
 | sourceController.serviceAccount.annotations | object | `{}` |  |
 | sourceController.serviceAccount.automount | bool | `true` |  |
 | sourceController.serviceAccount.create | bool | `true` |  |
-| sourceController.tag | string | `"v1.9.2"` |  |
+| sourceController.tag | string | `"v1.9.3"` |  |
 | sourceController.tolerations | list | `[]` |  |
 | sourceWatcher.affinity | object | `{}` |  |
 | sourceWatcher.annotations."prometheus.io/port" | string | `"8080"` |  |

--- a/charts/flux2/templates/image-automation-controller.crds.yaml
+++ b/charts/flux2/templates/image-automation-controller.crds.yaml
@@ -446,7 +446,6 @@ spec:
                 type: object
               observedSourceRevision:
                 description: |-
-                  ObservedPolicies []ObservedPolicy `json:"observedPolicies,omitempty"`
                   ObservedSourceRevision is the last observed source revision. This can be
                   used to determine if the source has been updated since last observation.
                 type: string

--- a/charts/flux2/templates/image-reflector-controller.crds.yaml
+++ b/charts/flux2/templates/image-reflector-controller.crds.yaml
@@ -628,7 +628,7 @@ spec:
                 description: |-
                   ObservedExclusionList is a list of observed exclusion list. It reflects
                   the exclusion rules used for the observed scan result in
-                  spec.lastScanResult.
+                  status.lastScanResult.
                 items:
                   type: string
                 type: array

--- a/charts/flux2/templates/source-controller.crds.yaml
+++ b/charts/flux2/templates/source-controller.crds.yaml
@@ -1464,7 +1464,7 @@ spec:
                 description: |-
                   URL is the dynamic fetch link for the latest Artifact.
                   It is provided on a "best effort" basis, and using the precise
-                  BucketStatus.Artifact data is recommended.
+                  HelmChartStatus.Artifact data is recommended.
                 type: string
             type: object
         type: object

--- a/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/helm-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
+        app.kubernetes.io/version: 2.9.2
         control-plane: controller
-        helm.sh/chart: flux2-2.19.0
+        helm.sh/chart: flux2-2.19.1
         labeltestkey: labeltestvalue
         labeltestkey2: labeltestvalue2
       name: helm-controller

--- a/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-automation-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
+        app.kubernetes.io/version: 2.9.2
         control-plane: controller
-        helm.sh/chart: flux2-2.19.0
+        helm.sh/chart: flux2-2.19.1
       name: image-automation-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-automation-controller:v1.2.2
+              image: ghcr.io/fluxcd/image-automation-controller:v1.2.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/image-reflector-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
+        app.kubernetes.io/version: 2.9.2
         control-plane: controller
-        helm.sh/chart: flux2-2.19.0
+        helm.sh/chart: flux2-2.19.1
       name: image-reflector-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/image-reflector-controller:v1.2.2
+              image: ghcr.io/fluxcd/image-reflector-controller:v1.2.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller-secret_test.yaml.snap
@@ -9,8 +9,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
-        helm.sh/chart: flux2-2.19.0
+        app.kubernetes.io/version: 2.9.2
+        helm.sh/chart: flux2-2.19.1
       name: test1
       namespace: NAMESPACE
     type: Opaque

--- a/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/kustomize-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
+        app.kubernetes.io/version: 2.9.2
         control-plane: controller
-        helm.sh/chart: flux2-2.19.0
+        helm.sh/chart: flux2-2.19.1
       name: kustomize-controller
     spec:
       replicas: 1
@@ -38,7 +38,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/kustomize-controller:v1.9.2
+              image: ghcr.io/fluxcd/kustomize-controller:v1.9.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/notification-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
+        app.kubernetes.io/version: 2.9.2
         control-plane: controller
-        helm.sh/chart: flux2-2.19.0
+        helm.sh/chart: flux2-2.19.1
       name: notification-controller
     spec:
       replicas: 1

--- a/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-install-job_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
-        helm.sh/chart: flux2-2.19.0
+        app.kubernetes.io/version: 2.9.2
+        helm.sh/chart: flux2-2.19.1
       name: RELEASE-NAME-flux-check
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.9.1
-            helm.sh/chart: flux2-2.19.0
+            app.kubernetes.io/version: 2.9.2
+            helm.sh/chart: flux2-2.19.1
           name: RELEASE-NAME
         spec:
           automountServiceAccountToken: true
@@ -34,7 +34,7 @@ should match snapshot of default values:
                 - --pre
                 - --namespace
                 - NAMESPACE
-              image: ghcr.io/fluxcd/flux-cli:v2.9.1
+              image: ghcr.io/fluxcd/flux-cli:v2.9.2
               name: flux-cli
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/pre-upgrade-migrate-resources_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
-        helm.sh/chart: flux2-2.19.0
+        app.kubernetes.io/version: 2.9.2
+        helm.sh/chart: flux2-2.19.1
       name: RELEASE-NAME-flux-migrate
     spec:
       backoffLimit: 1
@@ -22,8 +22,8 @@ should match snapshot of default values:
             app.kubernetes.io/instance: NAMESPACE
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/part-of: flux
-            app.kubernetes.io/version: 2.9.1
-            helm.sh/chart: flux2-2.19.0
+            app.kubernetes.io/version: 2.9.2
+            helm.sh/chart: flux2-2.19.1
           name: RELEASE-NAME
         spec:
           containers:
@@ -31,7 +31,7 @@ should match snapshot of default values:
                 - /usr/local/bin/flux
                 - migrate
                 - --timeout=5m
-              image: ghcr.io/fluxcd/flux-cli:v2.9.1
+              image: ghcr.io/fluxcd/flux-cli:v2.9.2
               name: flux-cli-migrate
               resources:
                 limits: {}

--- a/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-controller_test.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot of default values:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
+        app.kubernetes.io/version: 2.9.2
         control-plane: controller
-        helm.sh/chart: flux2-2.19.0
+        helm.sh/chart: flux2-2.19.1
       name: source-controller
     spec:
       replicas: 1
@@ -42,7 +42,7 @@ should match snapshot of default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: ghcr.io/fluxcd/source-controller:v1.9.2
+              image: ghcr.io/fluxcd/source-controller:v1.9.3
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
+++ b/charts/flux2/tests/__snapshot__/source-watcher.yaml.snap
@@ -8,9 +8,9 @@ should match snapshot with default values when enabled:
         app.kubernetes.io/instance: NAMESPACE
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: flux
-        app.kubernetes.io/version: 2.9.1
+        app.kubernetes.io/version: 2.9.2
         control-plane: controller
-        helm.sh/chart: flux2-2.19.0
+        helm.sh/chart: flux2-2.19.1
       name: source-watcher
     spec:
       replicas: 1

--- a/charts/flux2/values.yaml
+++ b/charts/flux2/values.yaml
@@ -38,7 +38,7 @@ clusterDomain: cluster.local
 
 cli:
   image: ghcr.io/fluxcd/flux-cli
-  tag: v2.9.1
+  tag: v2.9.2
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -99,7 +99,7 @@ helmController:
 imageAutomationController:
   create: true
   image: ghcr.io/fluxcd/image-automation-controller
-  tag: v1.2.2
+  tag: v1.2.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -127,7 +127,7 @@ imageAutomationController:
 imageReflectionController:
   create: true
   image: ghcr.io/fluxcd/image-reflector-controller
-  tag: v1.2.2
+  tag: v1.2.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -155,7 +155,7 @@ imageReflectionController:
 kustomizeController:
   create: true
   image: ghcr.io/fluxcd/kustomize-controller
-  tag: v1.9.2
+  tag: v1.9.3
   resources:
     limits: {}
     # cpu: 1000m
@@ -256,7 +256,7 @@ notificationController:
 sourceController:
   create: true
   image: ghcr.io/fluxcd/source-controller
-  tag: v1.9.2
+  tag: v1.9.3
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
<!--
Thank you for contributing to fluxcd-community/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Updates to the current flux upstream version

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] helm-docs are updated
- [X] Helm chart is tested
- [X] Update artifacthub.io/changes in Chart.yaml
- [X] Run `make reviewable`

❯ make
10:56:52 [ .. ] Fetch Flux2 GitRepo
HEAD is now at 6a650dba Merge pull request #5994 from fluxcd/update-components-release/v2.9.x
10:56:53 [ OK ] Fetch Flux2 GitRepo
10:56:53 [ .. ] Generating CRDs
10:56:54 [ OK ] Generating CRDs
10:56:54 [ .. ] Update chartname and chartversion string in test snapshots for flux2.
10:56:54 [ .. ] Update appVersion in ./charts/flux2/Chart.yaml
10:56:54 [ OK ] Version strings updated
10:56:54 [ .. ] Update chartname and chartversion string in test snapshots for flux2-multi-tenancy.
10:56:54 [ .. ] Update appVersion in ./charts/flux2-multi-tenancy/Chart.yaml
10:56:54 [ OK ] Version strings updated
10:56:54 [ .. ] Update chartname and chartversion string in test snapshots for flux2-notification.
10:56:54 [ .. ] Update appVersion in ./charts/flux2-notification/Chart.yaml
10:56:55 [ OK ] Version strings updated
10:56:55 [ .. ] Update chartname and chartversion string in test snapshots for flux2-sync.
10:56:55 [ .. ] Update appVersion in ./charts/flux2-sync/Chart.yaml
10:56:55 [ OK ] Version strings updated
helm-docs --chart-search-root=charts --template-files=../_readme_templates.gotmpl
INFO[2026-07-16T10:56:55+02:00] Found Chart directories [flux2, flux2-multi-tenancy, flux2-notification, flux2-sync] 
INFO[2026-07-16T10:56:55+02:00] Generating README Documentation for chart charts/flux2-multi-tenancy 
INFO[2026-07-16T10:56:55+02:00] Generating README Documentation for chart charts/flux2-sync 
INFO[2026-07-16T10:56:55+02:00] Generating README Documentation for chart charts/flux2-notification 
INFO[2026-07-16T10:56:55+02:00] Generating README Documentation for chart charts/flux2 

### Chart [ flux2-multi-tenancy ] charts/flux2-multi-tenancy/

 PASS  test kyverno deployment  charts/flux2-multi-tenancy/tests/kyverno-policy_test.yaml
 PASS  test kyverno deployment  charts/flux2-multi-tenancy/tests/kyverno-policy_test.yaml

Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshot:    2 passed, 2 total
Time:        4.459791ms


### Chart [ flux2 ] charts/flux2/

 PASS  test cluster reconciler  charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrole_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrolebinding.yaml
 PASS  test extra-manifests deployment  charts/flux2/tests/extra-manifests_test.yaml
 PASS  test helm-controller deployment  charts/flux2/tests/helm-controller_test.yaml
 PASS  test image-automation-controller deployment      charts/flux2/tests/image-automation-controller_test.yaml
 PASS  test image-reflector-controller deployment       charts/flux2/tests/image-reflector-controller_test.yaml
 PASS  test kustomize-controller-secret deployment      charts/flux2/tests/kustomize-controller-secret_test.yaml
 PASS  test kustomize-controller deployment     charts/flux2/tests/kustomize-controller_test.yaml
 PASS  test notification-controller deployment  charts/flux2/tests/notification-controller_test.yaml
 PASS  test pre-install-job hook        charts/flux2/tests/pre-install-job_test.yaml
 PASS  test pre-upgrade-migrate-resources job hook      charts/flux2/tests/pre-upgrade-migrate-resources_test.yaml
 PASS  test source-controller deployment        charts/flux2/tests/source-controller_test.yaml
 PASS  test source-watcher deployment   charts/flux2/tests/source-watcher.yaml
 PASS  test cluster reconciler  charts/flux2/tests/cluster-reconciler-clusterrolebinding_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrole_test.yaml
 PASS  test cluster reconciler impersonator clusterrole charts/flux2/tests/cluster-reconciler-impersonator-clusterrolebinding.yaml
 PASS  test extra-manifests deployment  charts/flux2/tests/extra-manifests_test.yaml
 PASS  test helm-controller deployment  charts/flux2/tests/helm-controller_test.yaml
 PASS  test image-automation-controller deployment      charts/flux2/tests/image-automation-controller_test.yaml
 PASS  test image-reflector-controller deployment       charts/flux2/tests/image-reflector-controller_test.yaml
 PASS  test kustomize-controller-secret deployment      charts/flux2/tests/kustomize-controller-secret_test.yaml
 PASS  test kustomize-controller deployment     charts/flux2/tests/kustomize-controller_test.yaml
 PASS  test notification-controller deployment  charts/flux2/tests/notification-controller_test.yaml
 PASS  test pre-install-job hook        charts/flux2/tests/pre-install-job_test.yaml
 PASS  test pre-upgrade-migrate-resources job hook      charts/flux2/tests/pre-upgrade-migrate-resources_test.yaml
 PASS  test source-controller deployment        charts/flux2/tests/source-controller_test.yaml
 PASS  test source-watcher deployment   charts/flux2/tests/source-watcher.yaml

Charts:      1 passed, 1 total
Test Suites: 28 passed, 28 total
Tests:       222 passed, 222 total
Snapshot:    20 passed, 20 total
Time:        189.08ms


### Chart [ flux2-sync ] charts/flux2-sync/

 PASS  test flux-gitrepository  charts/flux2-sync/tests/flux-gitrepository_test.yaml
 PASS  test flux-kustomization  charts/flux2-sync/tests/flux-kustomization_test.yaml
 PASS  test secret deployment   charts/flux2-sync/tests/secret_test.yaml
 PASS  test flux-gitrepository  charts/flux2-sync/tests/flux-gitrepository_test.yaml
 PASS  test flux-kustomization  charts/flux2-sync/tests/flux-kustomization_test.yaml
 PASS  test secret deployment   charts/flux2-sync/tests/secret_test.yaml

Charts:      1 passed, 1 total
Test Suites: 6 passed, 6 total
Tests:       12 passed, 12 total
Snapshot:    8 passed, 8 total
Time:        6.770584ms


### Chart [ flux2-notification ] charts/flux2-notification/

 PASS  test alert deployment    charts/flux2-notification/tests/alert_test.yaml
 PASS  test provider deployment charts/flux2-notification/tests/provider_test.yaml
 PASS  test secret deployment   charts/flux2-notification/tests/secret_test.yaml
 PASS  test alert deployment    charts/flux2-notification/tests/alert_test.yaml
 PASS  test provider deployment charts/flux2-notification/tests/provider_test.yaml
 PASS  test secret deployment   charts/flux2-notification/tests/secret_test.yaml

Charts:      1 passed, 1 total
Test Suites: 6 passed, 6 total
Tests:       14 passed, 14 total
Snapshot:    6 passed, 6 total
Time:        6.277292ms

10:56:55 [ .. ] checking that branch is clean
10:56:55 [ OK ] branch is clean