### PR TITLE
feat: add podmonitor capability check

### DIFF
--- a/charts/flux2/templates/podmonitor.yaml
+++ b/charts/flux2/templates/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus.podMonitor.create }}
+{{- if and .Values.prometheus.podMonitor.create (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:


### PR DESCRIPTION
<!--
https://github.com/fluxcd-community/helm-charts/issues/291

#### PodMonitor does not have a capability check

#### Special notes for your reviewer:
We are simply adding a capability check for podmonitor that ensures we don't break common gitops cluster bootstraps.
Here is an example from another repo
https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-redis-exporter/templates/servicemonitor.yaml

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/fluxcd-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [ ] helm-docs are updated
- [ ] Helm chart is tested
- [ ] Update artifacthub.io/changes in Chart.yaml
- [ ] Run `make reviewable`
